### PR TITLE
fix: battery low display

### DIFF
--- a/src/components/value-decorators/PowerSource.tsx
+++ b/src/components/value-decorators/PowerSource.tsx
@@ -52,15 +52,9 @@ const PowerSource = memo((props: PowerSourceProps) => {
                     batteryIcon = faBatteryHalf;
                 } else if (batteryPercent >= 20) {
                     batteryIcon = faBatteryQuarter;
-                } else if (batteryPercent >= 10) {
+                } else {
                     batteryIcon = faBatteryEmpty;
                     fade = true;
-                } else {
-                    return (
-                        <span className="animate-pulse text-error" role="alert">
-                            {batteryPercent}%
-                        </span>
-                    );
                 }
             } else if (batteryState != null) {
                 batteryFormatted = batteryState;
@@ -92,10 +86,10 @@ const PowerSource = memo((props: PowerSourceProps) => {
             }
 
             return (
-                <>
-                    <FontAwesomeIcon icon={batteryIcon} fade={fade} title={title} className={fade ? "text-error" : ""} {...rest} />
+                <span className={fade ? "text-error" : ""}>
+                    <FontAwesomeIcon icon={batteryIcon} fade={fade} title={title} {...rest} />
                     {showLevel && <span className="ps-2">{batteryFormatted}</span>}
-                </>
+                </span>
             );
         }
         case "Mains (single phase)":

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -54,6 +54,7 @@
         "failed": "Failed",
         "disabled": "Disabled",
         "hide_disabled": "Hide disabled",
+        "battery_low_only": "Battery low only",
         "execute": "Execute",
         "command": "Command",
         "payload": "Payload",


### PR DESCRIPTION
- always display icon+value even when low
- add ability to filter Devices table to show battery low only (`battery` below 20%, or `battery_state` is "low", or `battery_low` is true)