### PR TITLE
feat: standalone running, with Z2M instance switching

### DIFF
--- a/.docker/scripts/100-envsubst-on-app-envs.sh
+++ b/.docker/scripts/100-envsubst-on-app-envs.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -ex
+
+# find the file with the template envs
+envs=$(ls -t /usr/share/nginx/html/assets/envs*.js | head -n1)
+
+envsubst < "$envs" > ./envs_temp
+cp ./envs_temp "$envs"
+rm ./envs_temp

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.vscode
+.github
+coverage
+dist
+node_modules
+screenshots
+scripts
+test
+.dockerignore
+Dockerfile

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: [Publish package to npmjs]
     types: [completed]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,7 +14,7 @@ env:
 
 jobs:
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -1,0 +1,57 @@
+name: Build container
+
+on:
+  workflow_run:
+    workflows: [Publish package to npmjs]
+    types: [completed]
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to the GitHub container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker setup - QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Docker setup - Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+            images: |
+                ghcr.io/nerivec/zigbee2mqtt-windfront
+            tags: |
+                type=semver,pattern={{version}}
+                type=semver,pattern={{major}}.{{minor}}
+                type=semver,pattern={{major}}
+
+      - name: Docker build and push
+        uses: docker/build-push-action@v6
+        with:
+            context: .
+            file: Dockerfile
+            platforms: linux/arm64/v8,linux/amd64,linux/arm/v6,linux/arm/v7,linux/riscv64,linux/386
+            tags: ${{ steps.meta.outputs.tags }}
+            push: true
+            build-args: |
+                VERSION=${{ github.ref_name }}
+                DATE=${{ github.event.repository.updated_at }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+COPY . .
+
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
+
+RUN npm run build
+
+FROM nginx:alpine-slim AS prod
+
+ARG DATE
+ARG VERSION
+
+LABEL org.opencontainers.image.authors="Nerivec"
+LABEL org.opencontainers.image.title="Zigbee2MQTT WindFront"
+LABEL org.opencontainers.image.description="Open Source frontend for Zigbee2MQTT"
+LABEL org.opencontainers.image.url="https://github.com/Nerivec/zigbee2mqtt-windfront"
+LABEL org.opencontainers.image.documentation="https://github.com/Nerivec/zigbee2mqtt-windfront/wiki"
+LABEL org.opencontainers.image.source="https://github.com/Nerivec/zigbee2mqtt-windfront"
+LABEL org.opencontainers.image.licenses="GPL-3.0-or-later"
+LABEL org.opencontainers.image.created=${DATE}
+LABEL org.opencontainers.image.version=${VERSION}
+
+EXPOSE 80
+
+COPY .docker/scripts/ /docker-entrypoint.d/
+
+WORKDIR /usr/share/nginx/html
+
+COPY --from=builder /app/dist ./

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 A frontend UI for [Zigbee2MQTT](https://github.com/Koenkk/zigbee2mqtt) using [tailwindcss](https://tailwindcss.com/) & [daisyui](https://daisyui.com).
 
+https://github.com/Nerivec/zigbee2mqtt-windfront/wiki
+
 > Based on https://github.com/nurikk/zigbee2mqtt-frontend
 
 > [!IMPORTANT]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  zigbee2mqtt-windfront:
+    build: .
+    container_name: zigbee2mqtt-windfront
+    image: ghcr.io/nerivec/zigbee2mqtt-windfront
+    restart: unless-stopped
+    ports:
+      - 80:80
+    networks:
+      - network
+    environment:
+      - Z2M_API_URLS=localhost:5173/api,localhost:8080/api
+      - Z2M_API_NAMES=Instance one,Instance two
+networks:
+  network:

--- a/src/WebSocketApiRouterContext.ts
+++ b/src/WebSocketApiRouterContext.ts
@@ -3,5 +3,8 @@ import type { useApiWebSocket } from "./hooks/useApiWebSocket.js";
 
 export const WebSocketApiRouterContext = createContext<ReturnType<typeof useApiWebSocket>>({
     sendMessage: async (_topic, _payload) => {},
-    readyState: -1, // ReadyState.UNINSTANTIATED
+    readyState: -1,
+    apiUrls: [],
+    apiUrl: "",
+    setApiUrl: (_value) => {},
 });

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -64,7 +64,7 @@ const ThemeSwitcher = memo(() => {
                     <input
                         type="radio"
                         name="theme-dropdown"
-                        className="theme-controller w-full btn btn-block btn-ghost"
+                        className={`theme-controller w-full btn btn-sm btn-block ${currentTheme === theme.toLowerCase() ? "btn-primary" : "btn-ghost"}`}
                         aria-label={theme || "Default"}
                         value={theme.toLowerCase()}
                         onChange={() => setCurrentTheme(theme.toLowerCase())}

--- a/src/components/navbar/ApiUrlSwitcher.tsx
+++ b/src/components/navbar/ApiUrlSwitcher.tsx
@@ -1,0 +1,55 @@
+import { faServer } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { memo, useContext } from "react";
+import { useTranslation } from "react-i18next";
+import { ReadyState } from "react-use-websocket";
+import { WebSocketApiRouterContext } from "../../WebSocketApiRouterContext";
+import { Z2M_API_NAMES } from "../../envs";
+import PopoverDropdown from "../PopoverDropdown";
+
+const CONNECTION_STATUS = {
+    [ReadyState.CONNECTING]: "text-info",
+    [ReadyState.OPEN]: "text-success",
+    [ReadyState.CLOSING]: "text-warning",
+    [ReadyState.CLOSED]: "text-error",
+    [ReadyState.UNINSTANTIATED]: "text-error",
+};
+
+const ApiUrlSwitcher = memo(() => {
+    const { t } = useTranslation("navbar");
+    const { readyState, apiUrls, apiUrl, setApiUrl } = useContext(WebSocketApiRouterContext);
+    const apiNames = import.meta.env.VITE_Z2M_API_NAMES?.split(",") ?? (Z2M_API_NAMES.startsWith("${") ? apiUrls : Z2M_API_NAMES.split(","));
+
+    return (
+        <PopoverDropdown
+            name="api-url-switcher"
+            buttonChildren={
+                <FontAwesomeIcon
+                    icon={faServer}
+                    className={CONNECTION_STATUS[readyState]}
+                    title={`${t("websocket_status")}: ${ReadyState[readyState]}`}
+                />
+            }
+            buttonStyle="mx-1"
+            dropdownStyle="dropdown-end"
+        >
+            {apiUrls.map((url, i) => (
+                <li
+                    key={url}
+                    onClick={() => setApiUrl(url)}
+                    onKeyUp={(e) => {
+                        if (e.key === "enter") {
+                            setApiUrl(url);
+                        }
+                    }}
+                >
+                    <span className={`btn btn-sm btn-block ${apiUrl === url ? "btn-primary" : "btn-ghost"}`}>
+                        {apiNames[i] && apiNames[i] !== url ? `${apiNames[i]} (${url})` : url}
+                    </span>
+                </li>
+            ))}
+        </PopoverDropdown>
+    );
+});
+
+export default ApiUrlSwitcher;

--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -1,16 +1,14 @@
-import { useContext, useMemo } from "react";
-
 import { faBars } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useContext, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, NavLink } from "react-router";
-import { ReadyState } from "react-use-websocket";
 import { WebSocketApiRouterContext } from "../../WebSocketApiRouterContext.js";
 import { useAppSelector } from "../../hooks/useApp.js";
 import LanguageSwitcher from "../../i18n/LanguageSwitcher.js";
-import { isIframe } from "../../utils.js";
 import ConfirmButton from "../ConfirmButton.js";
 import ThemeSwitcher from "../ThemeSwitcher.js";
+import ApiUrlSwitcher from "./ApiUrlSwitcher.js";
 import PermitJoinButton from "./PermitJoinButton.js";
 
 const URLS = [
@@ -48,19 +46,10 @@ const URLS = [
     },
 ];
 
-const CONNECTION_STATUS = {
-    [ReadyState.CONNECTING]: "status-info",
-    [ReadyState.OPEN]: "status-success",
-    [ReadyState.CLOSING]: "status-warning",
-    [ReadyState.CLOSED]: "status-error",
-    [ReadyState.UNINSTANTIATED]: "status-error",
-};
-
 const NavBar = () => {
     const { t } = useTranslation(["navbar", "common"]);
     const restartRequired = useAppSelector((state) => state.bridgeInfo.restart_required);
-    const { sendMessage, readyState } = useContext(WebSocketApiRouterContext);
-    const connectionStatus = CONNECTION_STATUS[readyState];
+    const { sendMessage } = useContext(WebSocketApiRouterContext);
 
     const links = useMemo(
         () => (
@@ -106,7 +95,11 @@ const NavBar = () => {
                     </ul>
                 </div>
             </div>
-            <Link to="/" className="link link-hover me-1" title={isIframe() ? `Zigbee2MQTT@${document.location.hostname}` : ""}>
+            <Link
+                to="/"
+                className="link link-hover me-1"
+                title={window.location !== window.parent.location ? `Zigbee2MQTT@${document.location.hostname}` : undefined}
+            >
                 Zigbee2MQTT
             </Link>
             <div className="navbar-center hidden lg:flex">
@@ -118,11 +111,8 @@ const NavBar = () => {
                     {showRestart}
                     <LanguageSwitcher />
                     <ThemeSwitcher />
+                    <ApiUrlSwitcher />
                 </ul>
-                <div className="inline-grid *:[grid-area:1/1]" title={`${t("websocket_status")}: ${ReadyState[readyState]}`}>
-                    <div className={`status ${connectionStatus} animate-ping`} />
-                    <div className={`status ${connectionStatus}`} />
-                </div>
             </div>
         </div>
     );

--- a/src/components/navbar/PermitJoinButton.tsx
+++ b/src/components/navbar/PermitJoinButton.tsx
@@ -34,10 +34,16 @@ export default function PermitJoinButton() {
         for (const device of devices) {
             if (device.type === "Coordinator" || device.type === "Router") {
                 filteredDevices.push(
-                    <li key={device.friendly_name}>
-                        <Button<Device> item={device} className="dropdown-item" onClick={(device) => setSelectedRouter(device)}>
-                            {device.friendly_name}
-                        </Button>
+                    <li
+                        key={device.friendly_name}
+                        onClick={() => setSelectedRouter(device)}
+                        onKeyUp={(e) => {
+                            if (e.key === "enter") {
+                                setSelectedRouter(device);
+                            }
+                        }}
+                    >
+                        <span className="btn btn-sm btn-block btn-ghost">{device.friendly_name}</span>
                     </li>,
                 );
             }
@@ -80,10 +86,16 @@ export default function PermitJoinButton() {
                     buttonStyle="join-item"
                     dropdownStyle="dropdown-end"
                 >
-                    <li key="all">
-                        <Button<Device> className="dropdown-item" onClick={() => setSelectedRouter(undefined)}>
-                            {t("all")}
-                        </Button>
+                    <li
+                        key="all"
+                        onClick={() => setSelectedRouter(undefined)}
+                        onKeyUp={(e) => {
+                            if (e.key === "enter") {
+                                setSelectedRouter(undefined);
+                            }
+                        }}
+                    >
+                        <span className="btn btn-sm btn-block btn-ghost">{t("all")}</span>
                     </li>
                     {routers}
                 </PopoverDropdown>

--- a/src/envs.ts
+++ b/src/envs.ts
@@ -1,0 +1,3 @@
+// templates replaced at runtime
+export const Z2M_API_URLS: NonNullable<ImportMetaEnv["VITE_Z2M_API_URLS"]> = "${Z2M_API_URLS}";
+export const Z2M_API_NAMES: NonNullable<ImportMetaEnv["VITE_Z2M_API_NAMES"]> = "${Z2M_API_NAMES}";

--- a/src/i18n/LanguageSwitcher.tsx
+++ b/src/i18n/LanguageSwitcher.tsx
@@ -45,13 +45,15 @@ const LanguageSwitcher = memo(() => {
                         }
                     }}
                 >
-                    <span className="btn btn-block btn-ghost">{LOCALES_NAMES_MAP[language]}</span>
+                    <span className={`btn btn-sm btn-block ${language === currentLanguage ? "btn-primary" : "btn-ghost"}`}>
+                        {LOCALES_NAMES_MAP[language]}
+                    </span>
                 </li>,
             );
         }
 
         return languages;
-    }, [i18n.changeLanguage, i18n.options.resources]);
+    }, [currentLanguage, i18n.changeLanguage, i18n.options.resources]);
 
     return (
         <PopoverDropdown name="locale-picker" buttonChildren={currentLanguage} buttonStyle="mx-1" dropdownStyle="dropdown-end">

--- a/src/store.ts
+++ b/src/store.ts
@@ -252,6 +252,13 @@ export const storeSlice = createSlice({
         addGeneratedExternalDefinition: (state, action: PayloadAction<Zigbee2MQTTAPI["bridge/response/device/generate_external_definition"]>) => {
             state.generatedExternalDefinitions[action.payload.id] = action.payload.source;
         },
+        reset: (state) => {
+            const defaultState = merge({}, initialState);
+
+            for (const key in defaultState) {
+                state[key] = defaultState[key];
+            }
+        },
     },
 });
 
@@ -281,6 +288,7 @@ export const {
     setBackup,
     setBackupPreparing,
     addGeneratedExternalDefinition,
+    reset,
 } = storeSlice.actions;
 
 export default store;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,10 +110,6 @@ export const getEndpoints = (entity?: Device | Group): Set<string | number> => {
 
 // #region Browser
 
-export const isSecurePage = (): boolean => location.protocol === "https:";
-
-export const isIframe = (): boolean => window.location !== window.parent.location;
-
 export const downloadAsZip = async (data: Record<string, unknown>, filename: string) => {
     const { default: JSZip } = await import("jszip");
     const zip = new JSZip();

--- a/src/vite.d.ts
+++ b/src/vite.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="vite/client" />
+
+interface ViteTypeOptions {
+    strictImportMetaEnv: unknown;
+}
+
+interface ImportMetaEnv {
+    readonly VITE_Z2M_API_URLS?: string;
+    readonly VITE_Z2M_API_NAMES?: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -15,6 +15,15 @@ export default defineConfig(async ({ command, mode }) => {
         build: {
             emptyOutDir: true,
             outDir: "../dist",
+            rollupOptions: {
+                output: {
+                    manualChunks(id: string) {
+                        if (/envs.ts/.test(id)) {
+                            return "envs";
+                        }
+                    },
+                },
+            },
         },
         test: {
             dir: "test",


### PR DESCRIPTION
@Koenkk can you take a look, let me know what you think?
This implementation requires no change in Zigbee2MQTT (though it might be good to provide an option to disable internal serving for when this is used).

cc: @thk-socal @thargy @KoalaWerewolf

Note: merging instances (as has been suggested before) would often require splitting the UI anyway to get a proper display of information/controls, don't think we can accommodate this for now (not with current UI architecture).

---

Docs for the wiki:

# [Experimental] Standalone serving (with multi-Zigbee2MQTT support)

You can run WindFront in a separate instance (independently of Zigbee2MQTT).
This allows you to control the serving in more details and you can also use the same interface for multiple Zigbee2MQTT instances (switch available in the nav bar).

> [!IMPORTANT]
> [Frontend](https://www.zigbee2mqtt.io/guide/configuration/frontend.html) needs to be enabled in the targeted Zigbee2MQTT instances.

## Docker

The container is based on `nginx:alpine-slim`.

### Configure environment variables

Make sure to configure [`docker-compose.yml`](https://github.com/Nerivec/zigbee2mqtt-windfront/blob/main/docker-compose.yml) to fit your needs.

- `Z2M_API_URLS` allows to specify the addresses of the Zigbee2MQTT instances that will be available to pick from (comma-separated values, no space, first is default). Example: `Z2M_API_URLS=one.local:8080/api,two.local:8080/api`
- `Z2M_API_NAMES` will label the corresponding URLs (if not supplied, labels will be URLs)

```sh
docker compose up -d zigbee2mqtt-windfront
```

WindFront should now be accessible at whatever location you configured (default: `localhost:80`).

### Updating

```sh
docker compose pull zigbee2mqtt-windfront
docker compose up -d zigbee2mqtt-windfront
```

## Baremetal

Environment variables are the same as the Docker setup, except with `VITE_` prefix: `VITE_Z2M_API_URLS`, `VITE_Z2M_API_NAMES`.

```sh
git clone --depth 1 https://github.com/Nerivec/zigbee2mqtt-windfront/
npm ci
# example: VITE_Z2M_API_URLS=localhost:5173/api,localhost:8080/api VITE_Z2M_API_NAMES=one,two npm run build
<ENVS> npm run build
```

> [!TIP]
> You can pass the argument `-b v0.0.0` to `git clone` to get a specific version (see: https://github.com/Nerivec/zigbee2mqtt-windfront/tags)

The content of the `dist` folder that will be created can then be served by your favorite software (nginx, etc.).

### Updating

```sh
git pull
npm ci
<ENVS> npm run build
```
