### PR TITLE
feat: network map theme support

### DIFF
--- a/src/components/PopoverDropdown.tsx
+++ b/src/components/PopoverDropdown.tsx
@@ -6,11 +6,12 @@ interface PopoverDropdownProps extends HTMLAttributes<HTMLUListElement> {
     /** If `ReactElement`, expected to be `<FontAwesomeIcon />`. */
     buttonChildren: ReactElement | string;
     buttonStyle?: string;
+    buttonDisabled?: boolean;
     dropdownStyle?: string;
 }
 
 const PopoverDropdown = memo((props: PopoverDropdownProps) => {
-    const { buttonChildren, children, name, buttonStyle, dropdownStyle } = props;
+    const { name, buttonChildren, buttonStyle, buttonDisabled, dropdownStyle, children } = props;
     const popoverId = `popover-${name}`;
     const anchorName = `--anchor-${name}`;
 
@@ -35,6 +36,7 @@ const PopoverDropdown = memo((props: PopoverDropdownProps) => {
                 className={`btn ${typeof buttonChildren === "string" ? "" : "btn-square"}${buttonStyle ? ` ${buttonStyle}` : ""}`}
                 popoverTarget={popoverId}
                 style={{ anchorName: anchorName } as CSSProperties}
+                disabled={buttonDisabled}
             >
                 {buttonChildren}
             </Button>

--- a/src/components/navbar/LanguageSwitcher.tsx
+++ b/src/components/navbar/LanguageSwitcher.tsx
@@ -1,6 +1,6 @@
 import { type JSX, memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import PopoverDropdown from "../components/PopoverDropdown.js";
+import PopoverDropdown from "../PopoverDropdown.js";
 
 const LOCALES_NAMES_MAP = {
     bg: "Български",

--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -4,12 +4,12 @@ import { useContext, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, NavLink } from "react-router";
 import { useAppSelector } from "../../hooks/useApp.js";
-import LanguageSwitcher from "../../i18n/LanguageSwitcher.js";
 import { WebSocketApiRouterContext } from "../../WebSocketApiRouterContext.js";
 import ConfirmButton from "../ConfirmButton.js";
-import ThemeSwitcher from "../ThemeSwitcher.js";
 import ApiUrlSwitcher from "./ApiUrlSwitcher.js";
+import LanguageSwitcher from "./LanguageSwitcher.js";
 import PermitJoinButton from "./PermitJoinButton.js";
+import ThemeSwitcher from "./ThemeSwitcher.js";
 
 const URLS = [
     {

--- a/src/components/navbar/ThemeSwitcher.tsx
+++ b/src/components/navbar/ThemeSwitcher.tsx
@@ -1,9 +1,10 @@
 import { faPaintBrush } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { memo, useEffect, useState } from "react";
+import { useLocation } from "react-router";
 import store2 from "store2";
-import { THEME_KEY } from "../localStoreConsts.js";
-import PopoverDropdown from "./PopoverDropdown.js";
+import { THEME_KEY } from "../../localStoreConsts.js";
+import PopoverDropdown from "../PopoverDropdown.js";
 
 const ALL_THEMES = [
     "", // "Default"
@@ -45,6 +46,7 @@ const ALL_THEMES = [
 ];
 
 const ThemeSwitcher = memo(() => {
+    const location = useLocation();
     const [currentTheme, setCurrentTheme] = useState<string>(store2.get(THEME_KEY, ""));
 
     useEffect(() => {
@@ -53,7 +55,13 @@ const ThemeSwitcher = memo(() => {
     }, [currentTheme]);
 
     return (
-        <PopoverDropdown name="theme-switcher" buttonChildren={<FontAwesomeIcon icon={faPaintBrush} />} dropdownStyle="dropdown-end">
+        <PopoverDropdown
+            name="theme-switcher"
+            buttonChildren={<FontAwesomeIcon icon={faPaintBrush} />}
+            dropdownStyle="dropdown-end"
+            // do not allow theme-switching while on network page due to rendering of reagraph
+            buttonDisabled={location.pathname === "/network"}
+        >
             {ALL_THEMES.map((theme) => (
                 <li key={theme || "default"}>
                     <input

--- a/src/components/network-page/index.tsx
+++ b/src/components/network-page/index.tsx
@@ -24,3 +24,17 @@ export const EDGE_RELATIONSHIP_FILL_COLORS = {
     [ZigbeeRelationship.NeighborIsASibling]: "#8888ff",
     // others ignored by Z2M
 };
+
+/**
+ * Convert a CSS color using `OffscreenCanvas` to RGBA.
+ * @param ctx Rendering context to convert color with.
+ * @param color expect in CSS format (e.g. `oklch(25.33% 0.016 252.42);`)
+ * @return rgb in CSS format (e.g. `rgba(29, 35, 42, 255);`)
+ */
+export function cssColorToRgba(ctx: OffscreenCanvasRenderingContext2D, color: string): string {
+    ctx.fillStyle = color;
+
+    ctx.fillRect(0, 0, 1, 1);
+
+    return `rgba(${ctx.getImageData(0, 0, 1, 1).data.join(", ")});`;
+}

--- a/src/components/network-page/raw-map/Legend.tsx
+++ b/src/components/network-page/raw-map/Legend.tsx
@@ -8,7 +8,7 @@ const Legend = memo(() => {
     const { t } = useTranslation("network");
 
     return (
-        <details className="collapse collapse-arrow bg-white text-black rounded-b-none">
+        <details className="collapse collapse-arrow rounded-b-none">
             <summary className="collapse-title font-semibold">{t("legend")}</summary>
             <div className="collapse-content text-sm">
                 <div className="flex flex-row flex-wrap gap-3 mb-2">
@@ -54,6 +54,7 @@ const Legend = memo(() => {
                         value to something else, then back to the one you want
                     </li>
                     <li>Edge colors are currently not working</li>
+                    <li>An undesired vertical offset is applied when starting to drag a node</li>
                 </ul>
             </div>
         </details>


### PR DESCRIPTION
- compute reagraph theme from current daisyui theme
- disable theme switching while on `/network` page to avoid issues with separate rendering of reagraph (_this should be removable once a few issues have been fixed in reagraph re theming_)

CC: @erdosip @JourMic