### PR TITLE
fix: update reagraph to 4.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "react-redux": "^9.2.0",
                 "react-router": "^7.7.0",
                 "react-use-websocket": "^4.13.0",
-                "reagraph": "^4.25.0",
+                "reagraph": "^4.26.0",
                 "store2": "^2.14.4",
                 "tailwindcss": "^4.1.4",
                 "timeago.js": "^4.0.2",
@@ -6537,9 +6537,9 @@
             }
         },
         "node_modules/reagraph": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/reagraph/-/reagraph-4.25.0.tgz",
-            "integrity": "sha512-vTXmFuHNO/OMvo5TNNjbUJqbKwnvbhQM76TODCdcP8f36j7UMJvASizSZt9r8eqYljo3ZNacR0v6r7867fQOmA==",
+            "version": "4.26.0",
+            "resolved": "https://registry.npmjs.org/reagraph/-/reagraph-4.26.0.tgz",
+            "integrity": "sha512-GDIdiagh/RR6jqeyJRaEBbbBILBP+Sq3ZPAcbBtIMq6+/aiMNRrDvZO+Ywi3Uig6KaF+q5NHGcBn/ER+ykUpQw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "react-redux": "^9.2.0",
         "react-router": "^7.7.0",
         "react-use-websocket": "^4.13.0",
-        "reagraph": "^4.25.0",
+        "reagraph": "^4.26.0",
         "store2": "^2.14.4",
         "tailwindcss": "^4.1.4",
         "timeago.js": "^4.0.2",

--- a/src/components/network-page/raw-map/Controls.tsx
+++ b/src/components/network-page/raw-map/Controls.tsx
@@ -181,6 +181,7 @@ const Controls = memo(
                         <option value="forceDirected3d">forceDirected3d</option>
                         <option value="radialOut2d">radialOut2d</option>
                         <option value="radialOut3d">radialOut3d</option>
+                        <option value="concentric2d">concentric2d</option>
                     </select>
                     <select className="select select-sm w-36" title={t("label_type")} value={labelType} onChange={onLabelTypeChange}>
                         <option value="" disabled>

--- a/src/components/network-page/raw-map/Legend.tsx
+++ b/src/components/network-page/raw-map/Legend.tsx
@@ -49,10 +49,6 @@ const Legend = memo(() => {
                 {/* XXX: temporary */}
                 <p className="text-xs mt-2">Known issues:</p>
                 <ul className="list-disc list-inside text-xs">
-                    <li>
-                        If you cannot see labels (names/LQIs) after the map has finished loading, zoom-in sufficiently, switch the "{t("label_type")}"
-                        value to something else, then back to the one you want
-                    </li>
                     <li>Edge colors are currently not working</li>
                     <li>An undesired vertical offset is applied when starting to drag a node</li>
                 </ul>

--- a/src/components/settings-page/tabs/Frontend.tsx
+++ b/src/components/settings-page/tabs/Frontend.tsx
@@ -191,6 +191,7 @@ export default function Frontend() {
                     <option value="forceDirected3d">forceDirected3d</option>
                     <option value="radialOut2d">radialOut2d</option>
                     <option value="radialOut3d">radialOut3d</option>
+                    <option value="concentric2d">concentric2d</option>
                 </SelectField>
                 <SelectField
                     name="network:label_type"


### PR DESCRIPTION
Fixes the edge visibility issues. Added new `concentric2d` layout for good measure.