### PR TITLE
fix: cleanup

### DIFF
--- a/src/components/settings-page/Stats.tsx
+++ b/src/components/settings-page/Stats.tsx
@@ -51,11 +51,12 @@ const Stats = memo((props: StatsProps) => {
                 continue;
             }
 
+            const typeStr = t(`zigbee:${device.type}`);
             const modelId = device.model_id || t("zigbee:unknown");
             const manufacturer = device.manufacturer || t("zigbee:unknown");
             const powerSource = t(`zigbee:${snakeCase(device.power_source || "unknown")}`);
 
-            byType[t(device.type)] = (byType[t(device.type)] || 0) + 1;
+            byType[typeStr] = (byType[typeStr] || 0) + 1;
             byPowerSource[powerSource] = (byPowerSource[powerSource] || 0) + 1;
             byModel[modelId] = (byModel[modelId] || 0) + 1;
             byVendor[manufacturer] = (byVendor[manufacturer] || 0) + 1;

--- a/src/components/settings-page/tabs/Frontend.tsx
+++ b/src/components/settings-page/tabs/Frontend.tsx
@@ -5,6 +5,7 @@ import store2 from "store2";
 import {
     AUTH_FLAG_KEY,
     DASHBOARD_COLUMN_DISPLAY_KEY,
+    DASHBOARD_FILTER_KEY,
     DEVICES_HIDE_DISABLED_KEY,
     HOMEPAGE_KEY,
     I18NEXTLNG_KEY,
@@ -15,6 +16,8 @@ import {
     NETWORK_MAP_NODE_STRENGTH_KEY,
     NETWORK_RAW_DISPLAY_TYPE_KEY,
     PERMIT_JOIN_TIME_KEY,
+    TABLE_COLUMN_FILTER_KEY,
+    TABLE_COLUMN_VISIBILITY_KEY,
     THEME_KEY,
     TOKEN_KEY,
 } from "../../../localStoreConsts.js";
@@ -74,6 +77,8 @@ export default function Frontend() {
     }, [networkMapLinkDistance]);
 
     const resetSettings = useCallback(() => {
+        const keys = store2.keys();
+
         store2.remove(THEME_KEY);
         store2.remove(HOMEPAGE_KEY);
         store2.remove(DASHBOARD_COLUMN_DISPLAY_KEY);
@@ -86,11 +91,13 @@ export default function Frontend() {
         store2.remove(NETWORK_MAP_LINK_DISTANCE_KEY);
         store2.remove(I18NEXTLNG_KEY);
         store2.remove(DEVICES_HIDE_DISABLED_KEY);
-        store2.remove("all-devices-column-visibility");
-        store2.remove("all-groups-column-visibility");
-        store2.remove("ota-devices-column-visibility");
-        store2.remove("touchlink-devices-column-visibility");
-        store2.remove("health-devices-column-visibility");
+        store2.remove(DASHBOARD_FILTER_KEY);
+
+        for (const key of keys) {
+            if (key.startsWith(TABLE_COLUMN_VISIBILITY_KEY) || key.startsWith(TABLE_COLUMN_FILTER_KEY)) {
+                store2.remove(key);
+            }
+        }
 
         window.location.reload();
     }, []);
@@ -98,6 +105,12 @@ export default function Frontend() {
     const resetAuth = useCallback(() => {
         store2.remove(TOKEN_KEY);
         store2.remove(AUTH_FLAG_KEY);
+
+        window.location.reload();
+    }, []);
+
+    const resetAll = useCallback(() => {
+        store2.clearAll();
 
         window.location.reload();
     }, []);
@@ -124,6 +137,15 @@ export default function Frontend() {
                         modalCancelLabel={t("common:cancel")}
                     >
                         {t("reset_auth")}
+                    </ConfirmButton>
+                    <ConfirmButton<void>
+                        className="btn btn-sm btn-error"
+                        onClick={resetAll}
+                        title={t("reset_all")}
+                        modalDescription={t("common:dialog_confirmation_prompt")}
+                        modalCancelLabel={t("common:cancel")}
+                    >
+                        {t("reset_all")}
                     </ConfirmButton>
                 </div>
             </div>

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -10,7 +10,7 @@ import {
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import store2 from "store2";
-import { TABLE_COLUMN_FILTER } from "../../localStoreConsts.js";
+import { TABLE_COLUMN_FILTER_KEY, TABLE_COLUMN_VISIBILITY_KEY } from "../../localStoreConsts.js";
 import TextFilter from "./TextFilter.js";
 
 interface Props<T> {
@@ -23,7 +23,7 @@ interface Props<T> {
 export default function Table<T>(props: Props<T>) {
     const { t } = useTranslation("common");
     const { id, columns, data, visibleColumns } = props;
-    const columnVisibilityStoreKey = `${id}-column-visibility`;
+    const columnVisibilityStoreKey = `${TABLE_COLUMN_VISIBILITY_KEY}_${id}`;
     const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>(store2.get(columnVisibilityStoreKey, visibleColumns ?? {}));
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
     const table = useReactTable({
@@ -106,7 +106,7 @@ export default function Table<T>(props: Props<T>) {
                                                         <TextFilter
                                                             getFilterValue={header.column.getFilterValue}
                                                             setFilterValue={header.column.setFilterValue}
-                                                            storeKey={`${TABLE_COLUMN_FILTER}_${id}_${header.column.id}`}
+                                                            storeKey={`${TABLE_COLUMN_FILTER_KEY}_${id}_${header.column.id}`}
                                                         />
                                                     </div>
                                                 ) : null}

--- a/src/components/value-decorators/Availability.tsx
+++ b/src/components/value-decorators/Availability.tsx
@@ -11,7 +11,7 @@ export type AvailabilityStateProps = {
 };
 
 const Availability = memo((props: AvailabilityStateProps): JSX.Element => {
-    const { t } = useTranslation(["availability"]);
+    const { t } = useTranslation("availability");
     const { availability, availabilityFeatureEnabled, availabilityEnabledForDevice, disabled } = props;
 
     if (disabled) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -217,6 +217,7 @@
         "frontend_notice": "These settings are stored locally in your browser. Using private windows or clearing the cache will reset them to defaults.",
         "reset_settings": "Reset settings",
         "reset_auth": "Reset auth",
+        "reset_all": "Reset all",
         "language": "Language",
         "theme": "Theme",
         "homepage": "Homepage",
@@ -340,7 +341,13 @@
         "submit_converter": "Submit converter",
         "request_support": "Request support",
         "report_problem": "Report problem",
-        "group": "Group"
+        "group": "Group",
+        "type": "Type",
+        "EndDevice": "End device",
+        "Router": "Router",
+        "GreenPower": "GreenPower",
+        "Unknown": "Unknown",
+        "Coordinator": "Coordinator"
     },
     "scene": {
         "manage_scenes_header": "Manage scenes",
@@ -359,9 +366,7 @@
         "byPowerSource": "By power source",
         "byVendor": "By vendor",
         "byModel": "By model",
-        "total": "Total",
-        "EndDevice": "End devices",
-        "Router": "Router"
+        "total": "Total"
     },
     "availability": {
         "availability": "Availability",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -217,6 +217,7 @@
         "frontend_notice": "Ces paramètres sont stockés localement dans votre navigateur. L'utilisation d'une fenêtre privée ou la suppression du cache les réinitialisera.",
         "reset_settings": "Réinitialiser les paramètres",
         "reset_auth": "Réinitialiser l'authentification",
+        "reset_all": "Réinitialiser tout",
         "language": "Langue",
         "theme": "Thème",
         "homepage": "Page d'accueil",
@@ -337,7 +338,13 @@
         "custom_clusters": "Clusters personnalisés",
         "other_zcl_clusters": "Autres clusters ZCL",
         "how_to_add_support": "Comment ajouter la prise en charge ?",
-        "group": "Groupe"
+        "group": "Groupe",
+        "type": "Type",
+        "EndDevice": "Appareil terminal",
+        "Router": "Routeur",
+        "GreenPower": "GreenPower",
+        "Unknown": "Inconnu",
+        "Coordinator": "Coordinateur"
     },
     "scene": {
         "manage_scenes_header": "Gérer les scènes",
@@ -356,9 +363,7 @@
         "byPowerSource": "Par source d'alimentation",
         "byVendor": "Par fournisseur",
         "byModel": "Par modèle",
-        "total": "Total",
-        "EndDevice": "Appareils terminaux",
-        "Router": "Routeur"
+        "total": "Total"
     },
     "availability": {
         "availability": "Disponibilité",

--- a/src/localStoreConsts.ts
+++ b/src/localStoreConsts.ts
@@ -18,7 +18,8 @@ export const NETWORK_MAP_LINK_DISTANCE_KEY = "network-map-link-distance";
 
 export const I18NEXTLNG_KEY = "i18nextLng";
 
-export const DEVICES_HIDE_DISABLED_KEY = "devices_hide_disabled";
+export const DEVICES_HIDE_DISABLED_KEY = "devices-hide-disabled";
 
-export const TABLE_COLUMN_FILTER = "table_column_filter";
-export const DASHBOARD_FILTER = "dashboard_filter";
+export const TABLE_COLUMN_VISIBILITY_KEY = "table-column-visibility";
+export const TABLE_COLUMN_FILTER_KEY = "table-column-filter";
+export const DASHBOARD_FILTER_KEY = "dashboard-filter";

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,7 +12,7 @@ import DeviceControlEditName from "../components/device/DeviceControlEditName.js
 import DebouncedInput from "../components/form-fields/DebouncedInput.js";
 import { RemoveDeviceModal } from "../components/modal/components/RemoveDeviceModal.js";
 import { useAppSelector } from "../hooks/useApp.js";
-import { DASHBOARD_COLUMN_DISPLAY_KEY, DASHBOARD_FILTER } from "../localStoreConsts.js";
+import { DASHBOARD_COLUMN_DISPLAY_KEY, DASHBOARD_FILTER_KEY } from "../localStoreConsts.js";
 import type { FeatureWithAnySubFeatures } from "../types.js";
 import { WebSocketApiRouterContext } from "../WebSocketApiRouterContext.js";
 
@@ -22,11 +22,11 @@ export default function Dashboard() {
     const devices = useAppSelector((state) => state.devices);
     const { sendMessage } = useContext(WebSocketApiRouterContext);
     const { t } = useTranslation(["zigbee", "settings"]);
-    const [filterValue, setFilterValue] = useState(store2.get(DASHBOARD_FILTER, ""));
+    const [filterValue, setFilterValue] = useState(store2.get(DASHBOARD_FILTER_KEY, ""));
     const [columnDisplay, setColumnDisplay] = useState<boolean>(store2.get(DASHBOARD_COLUMN_DISPLAY_KEY, false));
 
     useEffect(() => {
-        store2.set(DASHBOARD_FILTER, filterValue);
+        store2.set(DASHBOARD_FILTER_KEY, filterValue);
     }, [filterValue]);
 
     const renameDevice = useCallback(

--- a/src/pages/DevicesPage.tsx
+++ b/src/pages/DevicesPage.tsx
@@ -211,6 +211,17 @@ export default function DevicesPage(): JSX.Element {
                 filterFn: "includesString",
             },
             {
+                id: "type",
+                header: t("type"),
+                accessorFn: ({ device }) => t(device.type),
+                cell: ({
+                    row: {
+                        original: { device },
+                    },
+                }) => t(device.type),
+                enableColumnFilter: false,
+            },
+            {
                 id: "lqi",
                 header: t("lqi"),
                 accessorFn: ({ state }) => state.linkquality,
@@ -319,9 +330,11 @@ export default function DevicesPage(): JSX.Element {
             friendly_name: true,
             ieee_address: true,
             model: true,
+            type: false,
+            lqi: true,
             last_seen: bridgeConfig.advanced.last_seen !== "disable",
             availability: bridgeConfig.availability.enabled || data.some((device) => device.availabilityEnabledForDevice),
-            controls: true,
+            actions: true,
         }),
         [bridgeConfig.advanced.last_seen, bridgeConfig.availability.enabled, data],
     );


### PR DESCRIPTION
- cleanup some local store keys
- add ability to clear entire local store
- add `type` column in Devices table (hidden by default) fixes #132

> [!IMPORTANT]
> This will reset a few local store settings to defaults (hide disabled devices, table column visibility, table column filter, dashboard filter).

