### PR TITLE
fix: list payload format

### DIFF
--- a/src/components/features/List.tsx
+++ b/src/components/features/List.tsx
@@ -39,15 +39,35 @@ const List = memo((props: Props) => {
             setCurrentValue(value);
 
             if (!isRoot) {
-                onChange(feature.property ? { [feature.property]: value } : value);
+                let payloadValue = value;
+
+                if (feature.item_type.type !== "composite" && feature.item_type.name) {
+                    payloadValue = [];
+
+                    for (const val of value) {
+                        payloadValue.push(val[feature.item_type.name]);
+                    }
+                }
+
+                onChange(feature.property ? { [feature.property]: payloadValue } : payloadValue);
             }
         },
-        [feature.property, onChange, isRoot],
+        [feature.property, feature.item_type, onChange, isRoot],
     );
 
     const onRootApply = useCallback(() => {
-        onChange(feature.property ? { [feature.property]: currentValue } : currentValue);
-    }, [feature.property, onChange, currentValue]);
+        let payloadValue = currentValue;
+
+        if (feature.item_type.type !== "composite" && feature.item_type.name) {
+            payloadValue = [];
+
+            for (const val of currentValue) {
+                payloadValue.push(val[feature.item_type.name]);
+            }
+        }
+
+        onChange(feature.property ? { [feature.property]: payloadValue } : payloadValue);
+    }, [feature.property, feature.item_type, onChange, currentValue]);
 
     const { access = FeatureAccessMode.SET, item_type: itemType } = feature;
 


### PR DESCRIPTION
Fixes issue described in https://github.com/Koenkk/zigbee2mqtt/issues/28119

Changes non-`composite` `List` payload from:
```json
"options":{"no_occupancy_since":[{"time":1},{"time":2}]}
```
to:
```json
"options":{"no_occupancy_since":[1,2]}
```

@Koenkk I assume ZHC expects/supports this format everywhere? If because of some previous issue the payload's format was changed on ZHC side, in a util or something, to match that of frontend instead of the other way around, this would break that particular expose.