### PR TITLE
fix: show settings defaults and use them if null

### DIFF
--- a/src/components/json-schema/SettingsList.tsx
+++ b/src/components/json-schema/SettingsList.tsx
@@ -222,11 +222,15 @@ const groupProperties = (
                 const feature = propertyToField(
                     key,
                     property,
-                    data[key],
+                    data[key] ?? property.default,
                     set,
                     depth,
                     required.includes(key),
-                    property.description ? t(property.description, { defaultValue: property.description }) : undefined,
+                    property.description
+                        ? `${t(property.description)}${property.default != null ? ` (${t("common:default")}: ${property.default})` : ""}`
+                        : property.default != null
+                          ? `${t("common:default")}: ${property.default}}`
+                          : undefined,
                 );
 
                 if (feature) {
@@ -245,7 +249,7 @@ const groupProperties = (
 };
 
 export default function SettingsList({ schema, data, set, rootOnly }: SettingsListProps) {
-    const { t } = useTranslation("settingsSchemaDescriptions");
+    const { t } = useTranslation(["settingsSchemaDescriptions", "common"]);
 
     return (
         <div className="list bg-base-100">{schema.properties && groupProperties(t, schema.properties, data, set, 0, schema.required, rootOnly)}</div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -66,7 +66,8 @@
         "entries": "Entries",
         "source": "Source",
         "close_notifications": "Close notifications",
-        "more": "More"
+        "more": "More",
+        "default": "Default"
     },
     "devicePage": {
         "about": "About",


### PR DESCRIPTION
* fix: show settings defaults after description
* fix: use settings defaults if current config has nullish value (to properly reflect what Z2M is using)