### PR TITLE
Use nginx-unprivileged base image for improved security

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -38,8 +38,8 @@ http {
     resolver 127.0.0.11 ipv6=off;
 
     server {
-        listen       80;
-        listen  [::]:80;
+        listen       ${NGINX_PORT};
+        listen  [::]:${NGINX_PORT};
         server_name  localhost;
 
         location / {

--- a/.docker/scripts/90-envsubst-on-nginx-conf.sh
+++ b/.docker/scripts/90-envsubst-on-nginx-conf.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+set -ex
+
+config_file="/etc/nginx/nginx.conf"
+
+tmpfile=$(mktemp)
+envsubst '${NGINX_PORT}' < "$config_file" > "$tmpfile"
+mv "$tmpfile" "$config_file"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM nginxinc/nginx-unprivileged:alpine-slim AS prod
 
-EXPOSE 8080
+ENV NGINX_PORT=80
+
+EXPOSE 80
 
 COPY --chmod=755 .docker/scripts/ /docker-entrypoint.d/
 COPY --chown=nginx:root .docker/nginx.conf /etc/nginx/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: ghcr.io/nerivec/zigbee2mqtt-windfront
     restart: unless-stopped
     ports:
-      - 8080:8080
+      - 80:80
     networks:
       - network
     environment:


### PR DESCRIPTION
This PR modifies the Dockerfile (and as a result the docker-compose file and nginx config) to use an nginx image (https://github.com/nginx/docker-nginx-unprivileged) that runs unprivileged.

This effectively means:
- The container no longer runs as `root` (even though it ran nginx with its own user before, the container was still running with `root` user privileges)
- It is now using port `8080` instead of `80`