### PR TITLE
ISSUE #239: Implement dynamic mechanism to capture local dns resolver and update nginx.conf resolver configuration

### DIFF
--- a/.docker/nginx.conf.template
+++ b/.docker/nginx.conf.template
@@ -38,7 +38,7 @@ http {
         ''      close;
     }
 
-    resolver 127.0.0.11 ipv6=off;
+    resolver $NGINX_LOCAL_RESOLVERS ipv6=off;
 
     server {
         listen       80;

--- a/.docker/scripts/100-envsubst-on-nginx-conf.sh
+++ b/.docker/scripts/100-envsubst-on-nginx-conf.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_LOCAL_RESOLVERS:-}" ] || return 0
+
+# Substitute the variable in the template file and generate the final config.
+# `envsubst` is a standard utility that substitutes environment variables in shell format strings.
+envsubst '$NGINX_LOCAL_RESOLVERS' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ EXPOSE 80
 
 COPY .docker/scripts/ /docker-entrypoint.d/
 COPY .docker/nginx.conf /etc/nginx/
+COPY .docker/nginx.conf.template /etc/nginx/
 
-RUN chmod +x /docker-entrypoint.d/100-envsubst-on-app-envs.sh
+RUN chmod +x /docker-entrypoint.d/100-envsubst-on-app-envs.sh /docker-entrypoint.d/100-envsubst-on-nginx-conf.sh
 
 COPY dist/ /usr/share/nginx/html/


### PR DESCRIPTION
Took a quick shot at implementing an automatic mechanism to programmatically grab the local dns resolver ip address from /etc/resolv.conf and update the nginx.conf file resolver directive with it, removing the hardcoded configuration.
Tested on Kubernetes and on a local docker instance and working fine.
Probably needs a bit more testing and script sanitization.