### PR TITLE
Update nl.json

### DIFF
--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -288,7 +288,7 @@
         "select_scan_source": "Selecteer scanningsbron"
     },
     "values": {
-        "clear": "leegmaken",
+        "clear": "leeg",
         "closed": "gesloten",
         "false": "onwaar",
         "not_supported": "niet ondersteund",
@@ -341,8 +341,8 @@
         "network_address_dec": "Netwerkadres dec",
         "none": "Geen",
         "pic": "Afbeelding",
-        "power": "Vermogen",
-        "power_level": "vermogensniveau",
+        "power": "Energiebron",
+        "power_level": "energieniveau",
         "reconfigure": "Herconfigureren",
         "remove_device": "Apparaat verwijderen",
         "rename_device": "Apparaat hernoemen",


### PR DESCRIPTION
Improved some dutch labels.
"Power" was translated to "Vermogen", this translation is litealy correct but wrong in this context. More accurate would be "Power source" which translates in dutch to "Energiebron".

"Clear" was translated to "Leegmaken", this translation is literaly correct but wrong in this context. This as "Leegmaken" is an action, not a state. So i changed it to "leeg", which is more correct here.

hope this helps.. (Y)