### PR TITLE
fix: handle 0 values in getLinkQualityIcon

### DIFF
--- a/src/components/features/index.tsx
+++ b/src/components/features/index.tsx
@@ -579,7 +579,7 @@ const getTemperatureIcon = (temperature: number | undefined, unit: TemperatureUn
 export const getLinkQualityIcon = (linkQuality: number | undefined): [IconDefinition, className: string] => {
     let className = "";
 
-    if (linkQuality !== null && linkQuality !== undefined) {
+    if (linkQuality != null) {
         if (linkQuality < 75) {
             className = "text-error";
         } else if (linkQuality < 125) {


### PR DESCRIPTION
Hi,

simple fix for an issue I noticed earlier today:
I had a device that showed up with LQI of 0, but the  LQI icon in the device list was not showing any extra className like text-error – which is what I would expect.

—
Problem with the previous code: `0` in JS is "falsy", so the if check in the `getLinkQualityIcon` never evaluated to `true`.

Changed the if clause to check explicitly for "not undefined" fixes this error and an LQI / linkQuality value of 0 now also receives the "text-error" class.