### PR TITLE
feat: Enhance AddScene component to allow directly updating scenes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dist
 
 *storybook.log
 storybook-static
+
+# JetBrains IDEs
+.idea

--- a/src/components/device-page/AddUpdateScene.tsx
+++ b/src/components/device-page/AddUpdateScene.tsx
@@ -19,7 +19,7 @@ type AddSceneProps = {
     deviceState: DeviceState;
 };
 
-const AddScene = memo(({ sourceIdx, target, deviceState }: AddSceneProps) => {
+const AddUpdateScene = memo(({ sourceIdx, target, deviceState }: AddSceneProps) => {
     const { t } = useTranslation("scene");
     const [sceneId, setSceneId] = useState<number>(0);
     const [sceneName, setSceneName] = useState<string>("");

--- a/src/components/device-page/AddUpdateScene.tsx
+++ b/src/components/device-page/AddUpdateScene.tsx
@@ -9,7 +9,7 @@ import { sendMessage } from "../../websocket/WebSocketManager.js";
 import Button from "../Button.js";
 import DashboardFeatureWrapper from "../dashboard-page/DashboardFeatureWrapper.js";
 import Feature from "../features/Feature.js";
-import { getFeatureKey } from "../features/index.js";
+import { getFeatureKey } from "../features";
 import InputField from "../form-fields/InputField.js";
 import { getScenes } from "./index.js";
 
@@ -104,4 +104,4 @@ const AddUpdateScene = memo(({ sourceIdx, target, deviceState }: AddSceneProps) 
     );
 });
 
-export default AddScene;
+export default AddUpdateScene;

--- a/src/components/device-page/AddUpdateScene.tsx
+++ b/src/components/device-page/AddUpdateScene.tsx
@@ -148,7 +148,7 @@ const AddUpdateScene = ({ sourceIdx, target, deviceState }: AddSceneProps) => {
                 )}
             </div>
             {sceneInput.action === "add" ? (
-                <Button disabled={!isValidSceneId} onClick={onStoreClick} className="btn btn-primary">
+                <Button disabled={!isValidSceneId} onClick={onStoreClick} className="btn btn-primary tooltip" data-tip={t(($) => $.add_scene)}>
                     {t(($) => $.add, { ns: "common" })}
                 </Button>
             ) : (

--- a/src/components/device-page/tabs/Scene.tsx
+++ b/src/components/device-page/tabs/Scene.tsx
@@ -1,7 +1,7 @@
 import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "../../../store.js";
 import type { Device } from "../../../types.js";
-import AddScene from "../AddScene.js";
+import AddUpdateScene from "../AddUpdateScene";
 import RecallRemove from "../RecallRemove.js";
 
 type SceneProps = {
@@ -16,7 +16,7 @@ export default function Scene({ sourceIdx, device }: SceneProps) {
         <div className="flex flex-row flex-wrap gap-4 w-full">
             <div className="card card-border bg-base-200 border-base-300 rounded-box shadow-md flex-1">
                 <div className="card-body p-4">
-                    <AddScene sourceIdx={sourceIdx} target={device} deviceState={deviceState ?? {}} />
+                    <AddUpdateScene sourceIdx={sourceIdx} target={device} deviceState={deviceState ?? {}} />
                 </div>
             </div>
             <div className="card card-border bg-base-200 border-base-300 rounded-box shadow-md flex-1">

--- a/src/components/group-page/tabs/Devices.tsx
+++ b/src/components/group-page/tabs/Devices.tsx
@@ -1,7 +1,7 @@
 import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "../../../store.js";
 import type { Group } from "../../../types.js";
-import AddScene from "../../device-page/AddScene.js";
+import AddUpdateScene from "../../device-page/AddUpdateScene";
 import RecallRemove from "../../device-page/RecallRemove.js";
 import AddDeviceToGroup from "../AddDeviceToGroup.js";
 import GroupMembers from "../GroupMembers.js";
@@ -29,7 +29,7 @@ export default function Devices({ sourceIdx, group }: DevicesProps) {
                 </div>
                 <div className="card card-border bg-base-200 border-base-300 rounded-box shadow-md flex-1">
                     <div className="card-body p-4">
-                        <AddScene sourceIdx={sourceIdx} target={group} deviceState={{}} />
+                        <AddUpdateScene sourceIdx={sourceIdx} target={group} deviceState={{}} />
                     </div>
                 </div>
             </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -408,9 +408,11 @@
         "scene_id": "Scene ID",
         "recall": "Recall",
         "store": "Store",
+        "update": "Update",
         "remove_all": "Remove all",
         "select_scene": "Select Scene",
-        "scene_name": "Scene Name"
+        "scene_name": "Scene Name",
+        "update_scene": "Update Scene"
     },
     "stats": {
         "byType": "By device type",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -412,7 +412,8 @@
         "remove_all": "Remove all",
         "select_scene": "Select Scene",
         "scene_name": "Scene Name",
-        "update_scene": "Update Scene"
+        "update_scene": "Update Scene",
+        "add_scene": "Add Scene"
     },
     "stats": {
         "byType": "By device type",


### PR DESCRIPTION
Enhances the `AddScene` component, allowing scenes to be updated directly instead of requiring them to be deleted first.

- The action button will change dynamically depending on whether or not a scene already exists:
  - "Add" action: Behavior same as before.
  - "Update" action: When an existing scene ID is selected, the current scene name will be prefilled and the "Update" button will appear. This allows for quicker scene modifications and updates.
- A confirmation modal will be shown for "update" actions, decreasing the likelihood of unintended modifications.
- Deleting a single scene will update the state, switching from "Update" to "Add" actions.
- Deleting all scenes resets the component to its default empty state. 

[Kooha-2025-11-22-23-11-09.webm](https://github.com/user-attachments/assets/a4fe27ae-e792-4df2-a1ce-e1c42d2ab0b0)
