### PR TITLE
fix: treat `area1-4Occupancy` the same as `occupancy` for supporting devices that have multiple occupancy zones

### DIFF
--- a/src/components/features/index.tsx
+++ b/src/components/features/index.tsx
@@ -211,10 +211,10 @@ const ICON_MAP: Record<string, IconDefinition> = {
     vibration: faMobileVibrate,
     presence: faPerson,
     occupancy: faPerson,
-    Area1Occupancy: faPerson,
-    Area2Occupancy: faPerson,
-    Area3Occupancy: faPerson,
-    Area4Occupancy: faPerson,
+    area1Occupancy: faPerson,
+    area2Occupancy: faPerson,
+    area3Occupancy: faPerson,
+    area4Occupancy: faPerson,
     occupied: faPerson,
     vacancy: faPerson,
     vacant: faPerson,
@@ -645,10 +645,10 @@ export const getFeatureIcon = (name: string, value: unknown, unit?: unknown): [I
             break;
         }
         case "occupancy":
-        case "Area1Occupancy":
-        case "Area2Occupancy":
-        case "Area3Occupancy":
-        case "Area4Occupancy":
+        case "area1Occupancy":
+        case "area2Occupancy":
+        case "area3Occupancy":
+        case "area4Occupancy":
         case "presence": {
             if (value) {
                 className = "text-warning";

--- a/src/components/value-decorators/DisplayValue.tsx
+++ b/src/components/value-decorators/DisplayValue.tsx
@@ -15,10 +15,10 @@ const BooleanValueView = memo((props: DisplayValueProps) => {
             return value ? t(($) => $.closed) : t(($) => $.open);
         }
         case "occupancy":
-        case "Area1Occupancy":
-        case "Area2Occupancy":
-        case "Area3Occupancy":
-        case "Area4Occupancy": {
+        case "area1Occupancy":
+        case "area2Occupancy":
+        case "area3Occupancy":
+        case "area4Occupancy": {
             return value ? t(($) => $.occupied) : t(($) => $.clear);
         }
         case "water_leak": {


### PR DESCRIPTION
This allows for devices that have multiple occupancy zones to display them the same way as the base the `occupancy` property.

Used to support https://github.com/Koenkk/zigbee-herdsman-converters/pull/9899