### PR TITLE
feat: add group Exposes tab

### DIFF
--- a/src/components/device/DeviceCard.tsx
+++ b/src/components/device/DeviceCard.tsx
@@ -36,7 +36,7 @@ const DeviceCard = memo(
         featureWrapperClass,
         children,
     }: Props) => {
-        const { t } = useTranslation(["zigbee", "devicePage"]);
+        const { t } = useTranslation(["zigbee", "common"]);
         const endpointName = endpoint != null ? device.endpoints[endpoint]?.name : undefined;
         const displayedFeatures = useMemo(() => {
             const elements: JSX.Element[] = [];
@@ -99,7 +99,7 @@ const DeviceCard = memo(
                     </div>
                     <div className="flex flex-row justify-end mb-2">
                         <Link to={`/device/${sourceIdx}/${device.ieee_address}/exposes`} className="btn btn-xs">
-                            {t(($) => $.exposes, { ns: "devicePage" })} <FontAwesomeIcon icon={faRightLong} size="lg" />
+                            {t(($) => $.exposes, { ns: "common" })} <FontAwesomeIcon icon={faRightLong} size="lg" />
                         </Link>
                     </div>
                 </div>

--- a/src/components/group-page/tabs/Exposes.tsx
+++ b/src/components/group-page/tabs/Exposes.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useShallow } from "zustand/react/shallow";
+import { useAppStore } from "../../../store.js";
+import type { FeatureWithAnySubFeatures, Group } from "../../../types.js";
+import { sendMessage } from "../../../websocket/WebSocketManager.js";
+import Feature from "../../features/Feature.js";
+import FeatureWrapper from "../../features/FeatureWrapper.js";
+import { getFeatureKey } from "../../features/index.js";
+
+type ExposesProps = {
+    sourceIdx: number;
+    group: Group;
+};
+
+/**
+ * Use non-clashing Map keys.
+ * NOTE: fallback to `type` because despite the ZHC typing, `name` isn't actually always defined
+ */
+const getFeatureId = (feature: FeatureWithAnySubFeatures) =>
+    feature.property ? `__property_${feature.property}` : feature.name ? `__name_${feature.name}` : `__type_${feature.type}`;
+
+/**
+ * Recursively find common features to a reference set (including sub-features if any).
+ * Returns a list of cloned features, with possible sub-features.
+ */
+const findCommonFeatures = (
+    refFeatures: FeatureWithAnySubFeatures[],
+    otherFeatureMaps: Map<string, FeatureWithAnySubFeatures>[],
+): FeatureWithAnySubFeatures[] => {
+    const common: FeatureWithAnySubFeatures[] = [];
+
+    for (const refFeature of refFeatures) {
+        const refId = getFeatureId(refFeature);
+        const matchingFeatures: FeatureWithAnySubFeatures[] = [];
+
+        // check if feature exists in all other devices
+        for (const otherFeatureMap of otherFeatureMaps) {
+            const match = otherFeatureMap.get(refId);
+
+            if (!match) {
+                continue;
+            }
+
+            matchingFeatures.push(match);
+        }
+
+        if (matchingFeatures.length === 0) {
+            continue;
+        }
+
+        // clone the feature
+        const commonFeature = { ...refFeature };
+
+        // if feature has sub-features, recursively find common ones
+        if ("features" in refFeature && refFeature.features.length > 0) {
+            const otherSubFeaturesMaps: Map<string, FeatureWithAnySubFeatures>[] = [];
+
+            for (const matchingFeature of matchingFeatures) {
+                if ("features" in matchingFeature) {
+                    otherSubFeaturesMaps.push(new Map((matchingFeature.features as FeatureWithAnySubFeatures[]).map((f) => [getFeatureId(f), f])));
+                }
+            }
+
+            const commonSubFeatures = findCommonFeatures(refFeature.features as FeatureWithAnySubFeatures[], otherSubFeaturesMaps);
+
+            // only include feature if it has common sub-features
+            if (commonSubFeatures.length > 0) {
+                // check is superfluous, already done in wrapping if, just with the original (only required by typing)
+                if ("features" in commonFeature) {
+                    commonFeature.features = commonSubFeatures;
+                }
+
+                common.push(commonFeature);
+            }
+        } else {
+            common.push(commonFeature);
+        }
+    }
+
+    return common;
+};
+
+export default function Exposes({ sourceIdx, group }: ExposesProps) {
+    const { t } = useTranslation("common");
+    const devices = useAppStore(useShallow((state) => state.devices[sourceIdx]));
+    const deviceScenesFeatures = useAppStore(useShallow((state) => state.deviceScenesFeatures[sourceIdx]));
+    const firstMember = group.members.length > 0 ? group.members[0] : undefined;
+    const refDevice = firstMember ? devices.find((d) => d.ieee_address === firstMember.ieee_address) : undefined;
+    const refEndpointName = refDevice && firstMember ? refDevice.endpoints[firstMember.endpoint]?.name : undefined;
+
+    const groupData = useMemo(() => {
+        if (!refDevice) {
+            return [];
+        }
+
+        const refFeatures = deviceScenesFeatures[refDevice.ieee_address] ?? [];
+
+        if (refFeatures.length === 0) {
+            return [];
+        }
+
+        const refEndpointFeatures = refFeatures.filter(
+            // XXX: show if feature has no endpoint?
+            (f) => !f.endpoint || Number(f.endpoint) === firstMember?.endpoint || f.endpoint === refEndpointName,
+        );
+
+        if (group.members.length === 1) {
+            return refEndpointFeatures;
+        }
+
+        const otherMembersFeatures: Map<string, FeatureWithAnySubFeatures>[] = [];
+
+        for (let i = 1; i < group.members.length; i++) {
+            const member = group.members[i];
+            const memberFeatures = deviceScenesFeatures[member.ieee_address];
+
+            if (!memberFeatures || memberFeatures.length === 0) {
+                return [];
+            }
+
+            const memberEndpointFeaturesMap = new Map<string, FeatureWithAnySubFeatures>();
+
+            for (const memberFeature of memberFeatures) {
+                // XXX: show if feature has no endpoint?
+                if (
+                    !memberFeature.endpoint ||
+                    Number(memberFeature.endpoint) === member.endpoint ||
+                    memberFeature.endpoint === refDevice.endpoints[member.endpoint]?.name
+                ) {
+                    memberEndpointFeaturesMap.set(getFeatureId(memberFeature), memberFeature);
+                }
+            }
+
+            otherMembersFeatures.push(memberEndpointFeaturesMap);
+        }
+
+        return findCommonFeatures(refEndpointFeatures, otherMembersFeatures);
+    }, [firstMember?.endpoint, refDevice, refEndpointName, deviceScenesFeatures, group.members]);
+
+    const onChange = useCallback(
+        async (value: Record<string, unknown>) => {
+            await sendMessage<"{friendlyNameOrId}/set">(
+                sourceIdx,
+                // @ts-expect-error templated API endpoint
+                `${group.id}/set`,
+                value,
+            );
+        },
+        [sourceIdx, group.id],
+    );
+
+    const onRead = useCallback(
+        async (value: Record<string, unknown>) => {
+            await sendMessage<"{friendlyNameOrId}/get">(
+                sourceIdx,
+                // @ts-expect-error templated API endpoint
+                `${group.id}/get`,
+                value,
+            );
+        },
+        [sourceIdx, group.id],
+    );
+
+    return refDevice && groupData.length > 0 ? (
+        <div className="list bg-base-100">
+            {groupData.map((expose) => (
+                <Feature
+                    key={getFeatureKey(expose)}
+                    feature={expose}
+                    device={refDevice}
+                    deviceState={{}}
+                    onChange={onChange}
+                    onRead={onRead}
+                    featureWrapperClass={FeatureWrapper}
+                    parentFeatures={[]}
+                />
+            ))}
+        </div>
+    ) : (
+        t(($) => $.empty_exposes_definition)
+    );
+}

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Несъвпадащи типове",
         "sync": "Синхр.",
         "clear_self_as_source": "Премахни себе си като източник",
-        "sync_reporting": "Синхр. отчитане"
+        "sync_reporting": "Синхр. отчитане",
+        "exposes": "Експонирани функции"
     },
     "devicePage": {
         "about": "Относно",
@@ -109,7 +110,6 @@
         "state": "Състояние",
         "groups": "Групи",
         "scene": "Сцена",
-        "exposes": "Експонирани функции",
         "select_a_device": "Изберете устройство"
     },
     "groups": {

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Tipus no coincidents",
         "sync": "Sincron.",
         "clear_self_as_source": "Esborra't com a origen",
-        "sync_reporting": "Sincron. informes"
+        "sync_reporting": "Sincron. informes",
+        "exposes": "Funcions exposades"
     },
     "devicePage": {
         "about": "Quant a",
@@ -109,7 +110,6 @@
         "state": "Estat",
         "groups": "Grups",
         "scene": "Escena",
-        "exposes": "Funcions exposades",
         "select_a_device": "Seleccioneu un dispositiu"
     },
     "groups": {

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Nesouhlasící typy",
         "sync": "Synchron.",
         "clear_self_as_source": "Odebrat sebe jako zdroj",
-        "sync_reporting": "Synchron. reportování"
+        "sync_reporting": "Synchron. reportování",
+        "exposes": "Hlavní přehled"
     },
     "devicePage": {
         "about": "O zařízení",
@@ -109,7 +110,6 @@
         "state": "Stav",
         "groups": "Skupiny",
         "scene": "Scény",
-        "exposes": "Hlavní přehled",
         "select_a_device": "Vybrat zařízení"
     },
     "groups": {

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Uoverensstemmende typer",
         "sync": "Synk.",
         "clear_self_as_source": "Fjern dig selv som kilde",
-        "sync_reporting": "Synk. rapportering"
+        "sync_reporting": "Synk. rapportering",
+        "exposes": "Eksponerede funktioner"
     },
     "devicePage": {
         "about": "Om",
@@ -109,7 +110,6 @@
         "state": "Tilstand",
         "groups": "Grupper",
         "scene": "Scene",
-        "exposes": "Eksponerede funktioner",
         "select_a_device": "Vælg en enhed"
     },
     "groups": {

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Nicht übereinstimmende Typen",
         "sync": "Synch.",
         "clear_self_as_source": "Dich selbst als Quelle entfernen",
-        "sync_reporting": "Synch. Berichte"
+        "sync_reporting": "Synch. Berichte",
+        "exposes": "Expose-Funktionen"
     },
     "devicePage": {
         "about": "Info",
@@ -109,7 +110,6 @@
         "state": "Status",
         "groups": "Gruppen",
         "scene": "Szene",
-        "exposes": "Expose-Funktionen",
         "select_a_device": "Ein Gerät auswählen"
     },
     "groups": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Mismatching types",
         "sync": "Sync",
         "clear_self_as_source": "Clear self as source",
-        "sync_reporting": "Sync reporting"
+        "sync_reporting": "Sync reporting",
+        "exposes": "Exposes"
     },
     "devicePage": {
         "about": "About",
@@ -109,7 +110,6 @@
         "state": "State",
         "groups": "Groups",
         "scene": "Scene",
-        "exposes": "Exposes",
         "select_a_device": "Select a device"
     },
     "groups": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Tipos no coincidentes",
         "sync": "Sincron.",
         "clear_self_as_source": "Quitarme como fuente",
-        "sync_reporting": "Sincron. informes"
+        "sync_reporting": "Sincron. informes",
+        "exposes": "Funciones expuestas"
     },
     "devicePage": {
         "about": "Acerca de",
@@ -109,7 +110,6 @@
         "state": "Estado",
         "groups": "Grupos",
         "scene": "Escena",
-        "exposes": "Funciones expuestas",
         "select_a_device": "Seleccione un dispositivo"
     },
     "groups": {

--- a/src/i18n/locales/eu.json
+++ b/src/i18n/locales/eu.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Mota ez datorrenak",
         "sync": "Sinkron.",
         "clear_self_as_source": "Kendu zeure burua iturri gisa",
-        "sync_reporting": "Sinkron. txostenak"
+        "sync_reporting": "Sinkron. txostenak",
+        "exposes": "Esposatutako funtzioak"
     },
     "devicePage": {
         "about": "Honi buruz",
@@ -109,7 +110,6 @@
         "state": "Egoera",
         "groups": "Taldeak",
         "scene": "Eszena",
-        "exposes": "Esposatutako funtzioak",
         "select_a_device": "Hautatu gailu bat"
     },
     "groups": {

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Yhteensopimattomat tyypit",
         "sync": "Synk.",
         "clear_self_as_source": "Poista itsesi lähteenä",
-        "sync_reporting": "Synk. raportointi"
+        "sync_reporting": "Synk. raportointi",
+        "exposes": "Näkyvät toiminnot"
     },
     "devicePage": {
         "about": "Tietoja",
@@ -109,7 +110,6 @@
         "state": "Tila",
         "groups": "Ryhmät",
         "scene": "Skenaario",
-        "exposes": "Näkyvät toiminnot",
         "select_a_device": "Valitse laite"
     },
     "groups": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Types incompatibles",
         "sync": "Synchro",
         "clear_self_as_source": "Me retirer comme source",
-        "sync_reporting": "Synchro rapports"
+        "sync_reporting": "Synchro rapports",
+        "exposes": "Expositions"
     },
     "devicePage": {
         "about": "À propos",
@@ -109,7 +110,6 @@
         "state": "État",
         "groups": "Groupes",
         "scene": "Scène",
-        "exposes": "Expositions",
         "select_a_device": "Sélectionner un appareil"
     },
     "groups": {

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Nem egyező típusok",
         "sync": "Szinkr.",
         "clear_self_as_source": "Távolítsd el magad forrásként",
-        "sync_reporting": "Szinkr. jelentés"
+        "sync_reporting": "Szinkr. jelentés",
+        "exposes": "Exponált funkciók"
     },
     "devicePage": {
         "about": "Névjegy",
@@ -109,7 +110,6 @@
         "state": "Állapot",
         "groups": "Csoportok",
         "scene": "Jelenet",
-        "exposes": "Exponált funkciók",
         "select_a_device": "Válassz egy eszközt"
     },
     "groups": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Tipi non corrispondenti",
         "sync": "Sincron.",
         "clear_self_as_source": "Rimuovi te stesso come sorgente",
-        "sync_reporting": "Sincron. rapporti"
+        "sync_reporting": "Sincron. rapporti",
+        "exposes": "Funzioni esposte"
     },
     "devicePage": {
         "about": "Informazioni",
@@ -109,7 +110,6 @@
         "state": "Stato",
         "groups": "Gruppi",
         "scene": "Scena",
-        "exposes": "Funzioni esposte",
         "select_a_device": "Seleziona un dispositivo"
     },
     "groups": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -96,7 +96,8 @@
         "mismatching_types": "種類が一致しません",
         "sync": "同期",
         "clear_self_as_source": "自分をソースから外す",
-        "sync_reporting": "同期レポート"
+        "sync_reporting": "同期レポート",
+        "exposes": "公開機能"
     },
     "devicePage": {
         "about": "概要",
@@ -109,7 +110,6 @@
         "state": "状態",
         "groups": "グループ",
         "scene": "シーン",
-        "exposes": "公開機能",
         "select_a_device": "デバイスを選択"
     },
     "groups": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -96,7 +96,8 @@
         "mismatching_types": "형식이 일치하지 않음",
         "sync": "동기",
         "clear_self_as_source": "자신을 소스에서 제거",
-        "sync_reporting": "동기 리포팅"
+        "sync_reporting": "동기 리포팅",
+        "exposes": "노출 기능"
     },
     "devicePage": {
         "about": "정보",
@@ -109,7 +110,6 @@
         "state": "상태",
         "groups": "그룹",
         "scene": "씬",
-        "exposes": "노출 기능",
         "select_a_device": "디바이스를 선택하세요"
     },
     "groups": {

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Niet-overeenkomende typen",
         "sync": "Synchr.",
         "clear_self_as_source": "Verwijder jezelf als bron",
-        "sync_reporting": "Synchr. rapportage"
+        "sync_reporting": "Synchr. rapportage",
+        "exposes": "Blootgestelde functies"
     },
     "devicePage": {
         "about": "Over",
@@ -109,7 +110,6 @@
         "state": "Status",
         "groups": "Groepen",
         "scene": "Scene",
-        "exposes": "Blootgestelde functies",
         "select_a_device": "Selecteer een apparaat"
     },
     "groups": {

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Ulike typer",
         "sync": "Synk.",
         "clear_self_as_source": "Fjern deg selv som kilde",
-        "sync_reporting": "Synk. rapportering"
+        "sync_reporting": "Synk. rapportering",
+        "exposes": "Eksponerte funksjoner"
     },
     "devicePage": {
         "about": "Om",
@@ -109,7 +110,6 @@
         "state": "Tilstand",
         "groups": "Grupper",
         "scene": "Scene",
-        "exposes": "Eksponerte funksjoner",
         "select_a_device": "Velg en enhet"
     },
     "groups": {

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Niedopasowane typy",
         "sync": "Synchron.",
         "clear_self_as_source": "Usuń siebie jako źródło",
-        "sync_reporting": "Synchron. raporty"
+        "sync_reporting": "Synchron. raporty",
+        "exposes": "Eksponowane funkcje"
     },
     "devicePage": {
         "about": "O z2m",
@@ -109,7 +110,6 @@
         "state": "Stan",
         "groups": "Grupy",
         "scene": "Scena",
-        "exposes": "Eksponowane funkcje",
         "select_a_device": "Wybierz urządzenie"
     },
     "groups": {

--- a/src/i18n/locales/ptbr.json
+++ b/src/i18n/locales/ptbr.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Tipos incompatíveis",
         "sync": "Sincron.",
         "clear_self_as_source": "Remover a si mesmo como fonte",
-        "sync_reporting": "Sincron. relatórios"
+        "sync_reporting": "Sincron. relatórios",
+        "exposes": "Funções expostas"
     },
     "devicePage": {
         "about": "Sobre",
@@ -109,7 +110,6 @@
         "state": "Estado",
         "groups": "Grupos",
         "scene": "Cena",
-        "exposes": "Funções expostas",
         "select_a_device": "Selecione um dispositivo"
     },
     "groups": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Несовпадающие типы",
         "sync": "Синхр.",
         "clear_self_as_source": "Убрать себя как источник",
-        "sync_reporting": "Синхр. отчётность"
+        "sync_reporting": "Синхр. отчётность",
+        "exposes": "Свойства"
     },
     "devicePage": {
         "about": "Информация",
@@ -109,7 +110,6 @@
         "state": "Состояние",
         "groups": "Группы",
         "scene": "Сцена",
-        "exposes": "Свойства",
         "select_a_device": "Выберите устройство"
     },
     "groups": {

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Nezhodné typy",
         "sync": "Synchron.",
         "clear_self_as_source": "Odstrániť seba ako zdroj",
-        "sync_reporting": "Synchron. hlásenia"
+        "sync_reporting": "Synchron. hlásenia",
+        "exposes": "Funkcie"
     },
     "devicePage": {
         "about": "O zariadení",
@@ -109,7 +110,6 @@
         "state": "Stav",
         "groups": "Skupiny",
         "scene": "Scéna",
-        "exposes": "Funkcie",
         "select_a_device": "Vyberte zariadenie"
     },
     "groups": {

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Typer matchar inte",
         "sync": "Synk.",
         "clear_self_as_source": "Ta bort dig själv som källa",
-        "sync_reporting": "Synk. rapportering"
+        "sync_reporting": "Synk. rapportering",
+        "exposes": "Exponerade funktioner"
     },
     "devicePage": {
         "about": "Om",
@@ -109,7 +110,6 @@
         "state": "Status",
         "groups": "Grupper",
         "scene": "Scen",
-        "exposes": "Exponerade funktioner",
         "select_a_device": "Välj en enhet"
     },
     "groups": {

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Eşleşmeyen türler",
         "sync": "Senk.",
         "clear_self_as_source": "Kendini kaynak olarak kaldır",
-        "sync_reporting": "Senk. raporlama"
+        "sync_reporting": "Senk. raporlama",
+        "exposes": "Açığa çıkan işlevler"
     },
     "devicePage": {
         "about": "Hakkında",
@@ -109,7 +110,6 @@
         "state": "Durum",
         "groups": "Gruplar",
         "scene": "Sahne",
-        "exposes": "Açığa çıkan işlevler",
         "select_a_device": "Bir cihaz seçin"
     },
     "groups": {

--- a/src/i18n/locales/ua.json
+++ b/src/i18n/locales/ua.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Невідповідні типи",
         "sync": "Синхр.",
         "clear_self_as_source": "Прибрати себе як джерело",
-        "sync_reporting": "Синхр. звітність"
+        "sync_reporting": "Синхр. звітність",
+        "exposes": "Експоновані функції"
     },
     "devicePage": {
         "about": "Про",
@@ -109,7 +110,6 @@
         "state": "Стан",
         "groups": "Групи",
         "scene": "Сцена",
-        "exposes": "Експоновані функції",
         "select_a_device": "Виберіть пристрій"
     },
     "groups": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -96,7 +96,8 @@
         "mismatching_types": "Kiểu không khớp",
         "sync": "Đ.bộ",
         "clear_self_as_source": "Xóa bản thân làm nguồn",
-        "sync_reporting": "Đ.bộ báo cáo"
+        "sync_reporting": "Đ.bộ báo cáo",
+        "exposes": "Exposes"
     },
     "devicePage": {
         "about": "Giới thiệu",
@@ -109,7 +110,6 @@
         "state": "Trạng thái",
         "groups": "Nhóm",
         "scene": "Cảnh",
-        "exposes": "Exposes",
         "select_a_device": "Chọn một thiết bị"
     },
     "groups": {

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -96,7 +96,8 @@
         "mismatching_types": "类型不匹配",
         "sync": "同步",
         "clear_self_as_source": "清除自己作为来源",
-        "sync_reporting": "同步上报"
+        "sync_reporting": "同步上报",
+        "exposes": "暴露功能"
     },
     "devicePage": {
         "about": "关于",
@@ -109,7 +110,6 @@
         "state": "状态",
         "groups": "分组",
         "scene": "场景",
-        "exposes": "暴露功能",
         "select_a_device": "请选择一个设备"
     },
     "groups": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -96,7 +96,8 @@
         "mismatching_types": "類型不相符",
         "sync": "同步",
         "clear_self_as_source": "清除自己作為來源",
-        "sync_reporting": "同步回報"
+        "sync_reporting": "同步回報",
+        "exposes": "暴露功能"
     },
     "devicePage": {
         "about": "關於",
@@ -109,7 +110,6 @@
         "state": "狀態",
         "groups": "群組",
         "scene": "情境",
-        "exposes": "暴露功能",
         "select_a_device": "請選擇裝置"
     },
     "groups": {

--- a/src/pages/DevicePage.tsx
+++ b/src/pages/DevicePage.tsx
@@ -118,7 +118,7 @@ export default function DevicePage(): JSX.Element {
                 </NavLink>
                 <NavLink to={`/device/${numSourceIdx}/${deviceId}/exposes`} className={isTabActive}>
                     <FontAwesomeIcon icon={faWandMagic} className="me-2" />
-                    {t(($) => $.exposes)}
+                    {t(($) => $.exposes, { ns: "common" })}
                 </NavLink>
                 <NavLink to={`/device/${numSourceIdx}/${deviceId}/bind`} className={isTabActive}>
                     <FontAwesomeIcon icon={faLink} className="me-2" />

--- a/src/pages/GroupPage.tsx
+++ b/src/pages/GroupPage.tsx
@@ -10,7 +10,7 @@ import { useAppStore } from "../store.js";
 import type { Group } from "../types.js";
 import { getValidSourceIdx } from "../utils.js";
 
-export type TabName = "devices" | "settings";
+export type TabName = "devices" | "exposes" | "settings";
 
 type GroupPageUrlParams = {
     sourceIdx: `${number}`;
@@ -19,6 +19,7 @@ type GroupPageUrlParams = {
 };
 
 const DevicesTab = lazy(async () => await import("../components/group-page/tabs/Devices.js"));
+const ExposesTab = lazy(async () => await import("../components/group-page/tabs/Exposes.js"));
 const GroupSettingsTab = lazy(async () => await import("../components/group-page/tabs/GroupSettings.js"));
 
 function renderTab(sourceIdx: number, tab: TabName, group: Group) {
@@ -27,6 +28,8 @@ function renderTab(sourceIdx: number, tab: TabName, group: Group) {
     switch (tab) {
         case "devices":
             return <DevicesTab key={key} sourceIdx={sourceIdx} group={group} />;
+        case "exposes":
+            return <ExposesTab key={key} sourceIdx={sourceIdx} group={group} />;
         case "settings":
             return <GroupSettingsTab key={key} sourceIdx={sourceIdx} group={group} />;
     }
@@ -62,6 +65,10 @@ export default function GroupPage() {
                 <NavLink to={`/group/${numSourceIdx}/${groupId}/devices`} className={isTabActive}>
                     <FontAwesomeIcon icon={faObjectGroup} className="me-2" />
                     {t(($) => $.devices, { ns: "common" })}
+                </NavLink>
+                <NavLink to={`/group/${numSourceIdx}/${groupId}/exposes`} className={isTabActive}>
+                    <FontAwesomeIcon icon={faObjectGroup} className="me-2" />
+                    {t(($) => $.exposes, { ns: "common" })}
                 </NavLink>
                 <NavLink to={`/group/${numSourceIdx}/${groupId}/settings`} className={isTabActive}>
                     <FontAwesomeIcon icon={faCogs} className="me-2" />


### PR DESCRIPTION
Find the common features for devices (endpoints, technically) in a group to use as exposes. Can read and change said features which will publish to the group instead of individual devices.

We could technically replace the "common features", with "unique features", but I think this is safer for now. Once bugs are fixed for "common", we can look into "unique". :sweat_smile: 

Fixes https://github.com/Nerivec/zigbee2mqtt-windfront/issues/377

CC: @andrei-lazarov