### PR TITLE
Fix tooltips on device info page

### DIFF
--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -280,7 +280,7 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                         <div className="stat-title">{device.type}</div>
                         <div className="stat-value text-xl">
                             <span className="tooltip tooltip-bottom" data-tip={t(($) => $.ieee_address)}>
-                                {device.ieee_address}
+                                <span className="font-mono">{device.ieee_address}</span>
                             </span>
                         </div>
                         <div className="stat-desc">
@@ -296,11 +296,11 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                         <div className="stat-title">{t(($) => $.network_address)}</div>
                         <div className="stat-value text-xl">
                             <span className="tooltip tooltip-bottom" data-tip={t(($) => $.network_address_hex)}>
-                                {toHex(device.network_address)}
+                                <span className="font-mono">{toHex(device.network_address)}</span>
                             </span>
                         </div>
                         <div className="stat-desc">
-                            {t(($) => $.network_address_dec)}: {device.network_address}
+                            {t(($) => $.network_address_dec)}: <span className="font-mono">{device.network_address}</span>
                         </div>
                     </div>
                     <div className="stat px-3">


### PR DESCRIPTION
### before
<img width="55%"  alt="Screenshot From 2026-02-28 15-57-34" src="https://github.com/user-attachments/assets/f691bbdc-65c8-416c-9001-c29eb5a32ac9" />
<img width="55%"  alt="Screenshot From 2026-02-28 15-57-12" src="https://github.com/user-attachments/assets/de2da8d6-39cc-4797-838b-7938b2fb59d7" />
<img width="55%"  alt="Screenshot From 2026-02-28 15-57-01" src="https://github.com/user-attachments/assets/a1ce54ad-24f1-4cf6-89e8-dd2d842cd91d" />

### after
<img width="55%"  alt="Screenshot From 2026-02-28 16-23-13" src="https://github.com/user-attachments/assets/51c960d3-c586-4702-b971-d127c0c1ffdd" />
<img width="55%"  alt="Screenshot From 2026-02-28 16-22-58" src="https://github.com/user-attachments/assets/5ff682ee-a0f8-4220-a15c-c20134f77c67" />
<img width="55%"  alt="Screenshot From 2026-02-28 16-22-56" src="https://github.com/user-attachments/assets/80cd3770-bc85-4ea5-ad7f-c370e8759a8e" />
