### PR TITLE
fix: refactor device About page to eliminate some display issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "zigbee2mqtt-windfront",
-    "version": "2.9.1",
+    "version": "2.9.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "zigbee2mqtt-windfront",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "license": "GPL-3.0-or-later",
             "devDependencies": {
                 "@biomejs/biome": "^2.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zigbee2mqtt-windfront",
-    "version": "2.9.1",
+    "version": "2.9.2",
     "license": "GPL-3.0-or-later",
     "type": "module",
     "main": "./index.js",

--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -237,9 +237,9 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
     return (
         <div className="card lg:card-side bg-base-100">
             <figure className="w-64 h-64" style={{ overflow: "visible" }}>
-                <DeviceImage device={device} otaState={deviceState.update?.state} disabled={device.disabled} />
+                <DeviceImage device={device} otaState={deviceState.update?.state} disabled={device.disabled} noIndicator />
             </figure>
-            <div className="card-body">
+            <div className="card-body py-0 px-3">
                 <h2 className="card-title">
                     {device.friendly_name}
                     <DeviceControlEditName
@@ -247,7 +247,7 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                         name={device.friendly_name}
                         renameDevice={renameDevice}
                         homeassistantEnabled={homeassistantEnabled}
-                        style="btn-link btn-sm btn-square"
+                        style="btn-link btn-md btn-square"
                     />
                 </h2>
                 <div className="flex flex-row flex-wrap gap-2">
@@ -275,104 +275,107 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                     <pre className="inline text-wrap break-all">{device.description || ""}</pre>
                     <DeviceControlUpdateDesc device={device} setDeviceDescription={setDeviceDescription} />
                 </div>
-                <div className="stats stats-vertical lg:stats-horizontal shadow">
-                    <div className="stat px-3">
-                        <div className="stat-title">{device.type}</div>
-                        <div className="stat-value text-xl tooltip tooltip-bottom" data-tip={t(($) => $.ieee_address)}>
-                            {device.ieee_address}
-                        </div>
-                        <div className="stat-desc tooltip tooltip-top" data-tip="Organizationally Unique Identifier / IEEE Vendor Prefix">
-                            OUI: {oui}
-                        </div>
-                    </div>
-                    <div className="stat px-3">
-                        <div className="stat-title">{t(($) => $.network_address)}</div>
-                        <div className="stat-value text-xl tooltip tooltip-bottom" data-tip={t(($) => $.network_address_hex)}>
-                            {toHex(device.network_address)}
-                        </div>
-                        <div className="stat-desc">
-                            {t(($) => $.network_address_dec)}: {device.network_address}
-                        </div>
-                    </div>
-                    <div className="stat px-3">
-                        <div className="stat-title">{t(($) => $.power)}</div>
-                        <div className="stat-value text-xl">
-                            <PowerSource
-                                showLevel={true}
-                                device={device}
-                                batteryPercent={deviceState.battery as number}
-                                batteryState={deviceState.battery_state as string}
-                                batteryLow={deviceState.battery_low as boolean}
-                            />
-                        </div>
-                        <div className="stat-desc">
+                <div className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-2 text-wrap">
+                    <div className="font-semibold text-base-content/70">{t(($) => $.type)}</div>
+                    <div className="min-w-0">
+                        <p className="font-semibold">{device.type}</p>
+                        <p className="text-base-content/50">
                             {device.type === "GreenPower" ? "GreenPower" : t(($) => $[snakeCase(device.power_source)] || $.unknown)}
-                        </div>
+                            <span className="ms-3">
+                                <PowerSource
+                                    showLevel={true}
+                                    device={device}
+                                    batteryPercent={deviceState.battery as number}
+                                    batteryState={deviceState.battery_state as string}
+                                    batteryLow={deviceState.battery_low as boolean}
+                                />
+                            </span>
+                        </p>
                     </div>
-                </div>
-                <div className="stats stats-vertical lg:stats-horizontal shadow">
-                    <div className="stat px-3">
-                        <div className="stat-title">{t(($) => $.zigbee_model)}</div>
-                        <div className="stat-value text-xl">{device.model_id}</div>
-                        <div className="stat-desc">
+                    <div className="font-semibold text-base-content/70">{t(($) => $.ieee_address)}</div>
+                    <div className="min-w-0">
+                        <p className="font-semibold font-mono">{device.ieee_address}</p>
+                        <p className="text-base-content/50">
+                            <span className="tooltip tooltip-bottom" data-tip="Organizationally Unique Identifier / IEEE Vendor Prefix">
+                                OUI: {oui}
+                            </span>
+                        </p>
+                    </div>
+                    <div className="font-semibold text-base-content/70">{t(($) => $.network_address)}</div>
+                    <div className="min-w-0">
+                        <p className="font-semibold font-mono">
+                            <span className="tooltip tooltip-bottom" data-tip={t(($) => $.network_address_hex)}>
+                                {toHex(device.network_address)}
+                            </span>
+                        </p>
+                        <p className="text-base-content/50">
+                            {t(($) => $.network_address_dec)}: <span className="font-mono">{device.network_address}</span>
+                        </p>
+                    </div>
+                    <div className="font-semibold text-base-content/70">{t(($) => $.zigbee_model)}</div>
+                    <div className="min-w-0">
+                        <p className="font-semibold break-all">{device.model_id}</p>
+                        <p className="text-base-content/50">
                             {device.manufacturer} ({definitionDescription})
-                        </div>
+                        </p>
                     </div>
-                    <div className="stat px-3">
-                        <div className="stat-title">{t(($) => $.model)}</div>
-                        <div className="stat-value text-xl">
+                    <div className="font-semibold text-base-content/70">{t(($) => $.model)}</div>
+                    <div className="min-w-0">
+                        <p className="font-semibold break-all">
                             <ModelLink device={device} />
-                        </div>
-                        <div className="stat-desc">
+                        </p>
+                        <p className="text-base-content/50">
                             <VendorLink device={device} />
-                        </div>
+                        </p>
                     </div>
                     {device.software_build_id ? (
-                        <div className="stat px-3">
-                            <div className="stat-title">{t(($) => $.firmware_id)}</div>
-                            <div className="stat-value text-xl">{device.software_build_id || "N/A"}</div>
-                            <div className="stat-desc">{device.date_code || "N/A"}</div>
-                        </div>
+                        <>
+                            <div className="font-semibold text-base-content/70">{t(($) => $.firmware_id)}</div>
+                            <div className="min-w-0">
+                                <p className="font-semibold">{device.software_build_id || "N/A"}</p>
+                                <p className="text-base-content/50">{device.date_code || "N/A"}</p>
+                            </div>
+                        </>
                     ) : null}
                     {canOta ? (
-                        <div className="stat px-3">
-                            <div className="stat-title">{t(($) => $.firmware_version, { ns: "ota" })}</div>
-                            <div className="stat-value text-xl">
-                                {deviceState.update?.installed_version ?? t(($) => $.unknown)}
-                                <span className="ms-3">
-                                    <OtaControlGroup
-                                        sourceIdx={sourceIdx}
-                                        device={device}
-                                        otaSettings={bridgeConfig.ota}
-                                        state={deviceState.update}
-                                        onCheckClick={onOtaCheckClick}
-                                        onUpdateClick={onOtaUpdateClick}
-                                        onScheduleClick={onOtaScheduleClick}
-                                        onUnscheduleClick={onOtaUnscheduleClick}
-                                    />
-                                </span>
+                        <>
+                            <div className="font-semibold text-base-content/70">{t(($) => $.firmware_version, { ns: "ota" })}</div>
+                            <div className="min-w-0">
+                                <p className="font-semibold">
+                                    {deviceState.update?.installed_version ?? t(($) => $.unknown)}
+                                    <span className="ms-3">
+                                        <OtaControlGroup
+                                            sourceIdx={sourceIdx}
+                                            device={device}
+                                            otaSettings={bridgeConfig.ota}
+                                            state={deviceState.update}
+                                            onCheckClick={onOtaCheckClick}
+                                            onUpdateClick={onOtaUpdateClick}
+                                            onScheduleClick={onOtaScheduleClick}
+                                            onUnscheduleClick={onOtaUnscheduleClick}
+                                        />
+                                    </span>
+                                </p>
+                                {otaInstalledVersion ? (
+                                    <p className="text-base-content/50">
+                                        {t(($) => $.app, { ns: "ota" })}: {`${otaInstalledVersion[0]} build ${otaInstalledVersion[1]}`}
+                                        {" | "}
+                                        {t(($) => $.stack, { ns: "ota" })}: {`${otaInstalledVersion[2]} build ${otaInstalledVersion[3]}`}
+                                    </p>
+                                ) : null}
                             </div>
-                            {otaInstalledVersion ? (
-                                <div className="stat-desc">
-                                    {t(($) => $.app, { ns: "ota" })}: {`${otaInstalledVersion[0]} build ${otaInstalledVersion[1]}`}
-                                    {" | "}
-                                    {t(($) => $.stack, { ns: "ota" })}: {`${otaInstalledVersion[2]} build ${otaInstalledVersion[3]}`}
-                                </div>
-                            ) : null}
-                        </div>
+                        </>
                     ) : null}
-                </div>
-                <div className="stats stats-vertical lg:stats-horizontal shadow">
-                    <div className="stat px-3">
-                        <div className="stat-title">{t(($) => $.last_seen)}</div>
-                        <div className="stat-value text-xl">
+                    <div className="font-semibold text-base-content/70">{t(($) => $.last_seen)}</div>
+                    <div className="min-w-0">
+                        <p className="font-semibold">
                             <LastSeen
                                 config={bridgeConfig.advanced.last_seen}
                                 lastSeen={deviceState.last_seen}
                                 fallback={t(($) => $.disabled, { ns: "common" })}
                             />
-                        </div>
-                        <div className="stat-desc">
+                        </p>
+                        <p className="text-base-content/50">
                             {t(($) => $.availability, { ns: "availability" })}
                             {": "}
                             <Availability
@@ -381,38 +384,40 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                                 availabilityFeatureEnabled={bridgeConfig.availability.enabled}
                                 availabilityEnabledForDevice={deviceAvailability != null ? !!deviceAvailability : undefined}
                             />
-                        </div>
+                        </p>
                     </div>
                     {deviceRecentActivity && (
-                        <div className="stat px-3 min-w-0">
-                            <div className="stat-title">{t(($) => $.recent_activity, { ns: "common" })}</div>
-                            <div className="stat-value text-xl truncate">
-                                <SourceDot idx={sourceIdx} autoHide />
-                                {deviceRecentActivity.desc}
+                        <>
+                            <div className="font-semibold text-base-content/70">{t(($) => $.recent_activity, { ns: "common" })}</div>
+                            <div className="min-w-0">
+                                <p className="font-semibold break-all">
+                                    <SourceDot idx={sourceIdx} autoHide />
+                                    {deviceRecentActivity.desc}
+                                </p>
+                                <p className="text-base-content/50">{new Date(deviceRecentActivity.timestamp).toLocaleString()}</p>
                             </div>
-                            <div className="stat-desc">{new Date(deviceRecentActivity.timestamp).toLocaleString()}</div>
-                        </div>
+                        </>
                     )}
-                </div>
-                <div className="stats stats-vertical lg:stats-horizontal shadow">
-                    <div className="stat px-3">
-                        <div className="stat-title">MQTT</div>
-                        <div className="stat-value text-xl">
+                    <div className="font-semibold text-base-content/70">MQTT</div>
+                    <div className="min-w-0">
+                        <p className="font-semibold break-all">
                             {bridgeConfig.mqtt.base_topic}/{device.friendly_name}
-                        </div>
-                        <div className="stat-desc text-base-content/0">-</div>
+                        </p>
+                        <p className="text-base-content/0">-</p>
                     </div>
                     {MULTI_INSTANCE && (
-                        <div className="stat px-3">
-                            <div className="stat-title">{t(($) => $.source, { ns: "common" })}</div>
-                            <div className="stat-value text-xl">
-                                <SourceDot idx={sourceIdx} alwaysShowName />
+                        <>
+                            <div className="font-semibold text-base-content/70">{t(($) => $.source, { ns: "common" })}</div>
+                            <div className="min-w-0">
+                                <p className="font-semibold">
+                                    <SourceDot idx={sourceIdx} alwaysShowName />
+                                </p>
+                                <p className="text-base-content/50">{API_URLS[sourceIdx]}</p>
                             </div>
-                            <div className="stat-desc">{API_URLS[sourceIdx]}</div>
-                        </div>
+                        </>
                     )}
                 </div>
-                <div className="card-actions justify-end mt-2">
+                <div className="card-actions justify-center md:justify-end mt-2 me-4">
                     <ReportProblemLink sourceIdx={sourceIdx} device={device} />
                     <DeviceControlGroup
                         sourceIdx={sourceIdx}

--- a/src/components/device/DeviceControlUpdateDesc.tsx
+++ b/src/components/device/DeviceControlUpdateDesc.tsx
@@ -17,7 +17,7 @@ const DeviceControlUpdateDesc = memo(({ device, setDeviceDescription }: DeviceCo
 
     return (
         <Button<void>
-            className={`btn btn-link btn-sm${device.description ? " btn-square" : ""} tooltip-bottom`}
+            className={`btn btn-link btn-md ${device.description ? "btn-square" : ""} tooltip-bottom`}
             onClick={async () =>
                 await NiceModal.show(UpdateDeviceDescModal, {
                     device,

--- a/src/components/home-page/DevicePeek.tsx
+++ b/src/components/home-page/DevicePeek.tsx
@@ -81,13 +81,13 @@ const DevicePeek = memo(({ selection: { anchor, sourceIdx, device }, onClose }: 
                                 {device.friendly_name}
                             </Link>
                             <p className="truncate text-sm opacity-60">{description}</p>
-                            <span className="badge cursor-default tooltip tooltip-bottom" data-tip={t(($) => $.ieee_address)}>
+                            <span className="font-mono badge cursor-default tooltip tooltip-bottom" data-tip={t(($) => $.ieee_address)}>
                                 {device.ieee_address}
                             </span>
-                            <span className="badge cursor-default tooltip tooltip-bottom" data-tip={t(($) => $.network_address_hex)}>
+                            <span className="font-mono badge cursor-default tooltip tooltip-bottom" data-tip={t(($) => $.network_address_hex)}>
                                 {toHex(device.network_address, 4)}
                             </span>
-                            <span className="badge cursor-default tooltip tooltip-bottom" data-tip={t(($) => $.network_address_dec)}>
+                            <span className="font-mono badge cursor-default tooltip tooltip-bottom" data-tip={t(($) => $.network_address_dec)}>
                                 {device.network_address}
                             </span>
                         </div>

--- a/src/components/home-page/Hero.tsx
+++ b/src/components/home-page/Hero.tsx
@@ -54,7 +54,7 @@ const Hero = memo(
                     <h2 className="card-title">{t(($) => $.overview)}</h2>
                     <div className="flex flex-row flex-wrap justify-center gap-y-3">
                         {MULTI_INSTANCE ? (
-                            <div className="flex flex-row w-36 xl:w-48 px-2 py-1 gap-3 justify-center justify-center border-dashed border-s border-e border-current/25">
+                            <div className="flex flex-row w-36 xl:w-48 px-2 py-1 gap-3 justify-center border-dashed border-s border-e border-current/25">
                                 <div>
                                     <div className="text-sm text-base-content/70">{t(($) => $.instances)}</div>
                                     <div className={`font-semibold text-xl ${onlineInstances === totalInstances ? "" : "text-error"}`}>

--- a/src/components/network-page/raw-data/RawRelation.tsx
+++ b/src/components/network-page/raw-data/RawRelation.tsx
@@ -66,12 +66,15 @@ const RawRelation = memo(({ sourceIdx, relation, device, highlight, setHighlight
                 <ul>
                     <li>
                         <Link to={`/device/${sourceIdx}/${device.ieee_address}/info`} className="link link-hover">
-                            {t(($) => $.ieee_address, { ns: "zigbee" })}: {device.ieee_address}
+                            {t(($) => $.ieee_address, { ns: "zigbee" })}: <span className="font-mono">{device.ieee_address}</span>
                         </Link>
                     </li>
                     <li>
                         <Link to={`/device/${sourceIdx}/${device.ieee_address}/info`} className="link link-hover">
-                            {t(($) => $.network_address, { ns: "zigbee" })}: {toHex(device.network_address, 4)} ({device.network_address})
+                            {t(($) => $.network_address, { ns: "zigbee" })}:{" "}
+                            <span className="font-mono">
+                                {toHex(device.network_address, 4)} ({device.network_address})
+                            </span>
                         </Link>
                     </li>
                     <li>

--- a/src/components/settings-page/tabs/Health.tsx
+++ b/src/components/settings-page/tabs/Health.tsx
@@ -101,15 +101,21 @@ export default function Health({ sourceIdx }: HealthProps) {
                 }) => (
                     <>
                         <div>
-                            <Link to={`/device/${sourceIdx}/${device.ieee_address}/info`} className="link link-hover">
+                            <Link to={`/device/${sourceIdx}/${device.ieee_address}/info`} className="link link-hover font-mono">
                                 {device.ieee_address}
                             </Link>
                         </div>
                         <div className="flex flex-row gap-1">
-                            <span className="badge badge-ghost badge-sm cursor-default" title={t(($) => $.network_address_hex, { ns: "zigbee" })}>
+                            <span
+                                className="badge badge-ghost badge-sm cursor-default font-mono"
+                                title={t(($) => $.network_address_hex, { ns: "zigbee" })}
+                            >
                                 {toHex(device.network_address, 4)}
                             </span>
-                            <span className="badge badge-ghost badge-sm cursor-default" title={t(($) => $.network_address_dec, { ns: "zigbee" })}>
+                            <span
+                                className="badge badge-ghost badge-sm cursor-default font-mono"
+                                title={t(($) => $.network_address_dec, { ns: "zigbee" })}
+                            >
                                 {device.network_address}
                             </span>
                         </div>

--- a/src/pages/DevicesPage.tsx
+++ b/src/pages/DevicesPage.tsx
@@ -168,15 +168,15 @@ export default function DevicesPage(): JSX.Element {
                 }) => (
                     <>
                         <div>
-                            <Link to={`/device/${sourceIdx}/${device.ieee_address}/info`} className="link link-hover">
+                            <Link to={`/device/${sourceIdx}/${device.ieee_address}/info`} className="link link-hover font-mono">
                                 {device.ieee_address}
                             </Link>
                         </div>
                         <div className="flex flex-row gap-1">
-                            <span className="badge badge-ghost badge-sm cursor-default" title={t(($) => $.network_address_hex)}>
+                            <span className="badge badge-ghost badge-sm cursor-default font-mono" title={t(($) => $.network_address_hex)}>
                                 {toHex(device.network_address, 4)}
                             </span>
-                            <span className="badge badge-ghost badge-sm cursor-default" title={t(($) => $.network_address_dec)}>
+                            <span className="badge badge-ghost badge-sm cursor-default font-mono" title={t(($) => $.network_address_dec)}>
                                 {device.network_address}
                             </span>
                         </div>

--- a/src/pages/OtaPage.tsx
+++ b/src/pages/OtaPage.tsx
@@ -250,15 +250,21 @@ export default function OtaPage() {
                 }) => (
                     <>
                         <div>
-                            <Link to={`/device/${sourceIdx}/${device.ieee_address}/info`} className="link link-hover">
+                            <Link to={`/device/${sourceIdx}/${device.ieee_address}/info`} className="link link-hover font-mono">
                                 {device.ieee_address}
                             </Link>
                         </div>
                         <div className="flex flex-row gap-1">
-                            <span className="badge badge-ghost badge-sm cursor-default" title={t(($) => $.network_address_hex, { ns: "zigbee" })}>
+                            <span
+                                className="badge badge-ghost badge-sm cursor-default font-mono"
+                                title={t(($) => $.network_address_hex, { ns: "zigbee" })}
+                            >
                                 {toHex(device.network_address, 4)}
                             </span>
-                            <span className="badge badge-ghost badge-sm cursor-default" title={t(($) => $.network_address_dec, { ns: "zigbee" })}>
+                            <span
+                                className="badge badge-ghost badge-sm cursor-default font-mono"
+                                title={t(($) => $.network_address_dec, { ns: "zigbee" })}
+                            >
                                 {device.network_address}
                             </span>
                         </div>

--- a/src/pages/TouchlinkPage.tsx
+++ b/src/pages/TouchlinkPage.tsx
@@ -148,7 +148,7 @@ export default function TouchlinkPage() {
                 }) =>
                     friendlyName ? (
                         <div className="min-w-0">
-                            <Link to={`/device/${sourceIdx}/${touchlinkDevice.ieee_address}/info`} className="link link-hover truncate">
+                            <Link to={`/device/${sourceIdx}/${touchlinkDevice.ieee_address}/info`} className="link link-hover truncate font-mono">
                                 {touchlinkDevice.ieee_address}
                             </Link>
                         </div>


### PR DESCRIPTION
Fix some issues with screen sizes with previous design, notably tooltips, and recent activity (can be quite long), simpler grid should adapt better.
Also add mono to ieee/nwk addresses.

Supersedes & closes #450

Here's an example with one of the devices in the demo:
<img height="600" alt="deviceinfo" src="https://github.com/user-attachments/assets/6e70facd-4fd0-40e7-8766-567aed317404" />
<img height="600" alt="deviceinfo-mobile" src="https://github.com/user-attachments/assets/9a87b86f-608f-4f46-8696-95277207663e" />



_Could technically use 2 cols on larger screens, but would need extensive testing on "borderline" screen sizes, which always make a mess. In any case, it would end up with a blank space, either on right, or on bottom..._ :sweat_smile: 

CC: @andrei-lazarov 