### PR TITLE
fix: Add Z2M converter to issue template

### DIFF
--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -91,7 +91,6 @@ const ReportProblemLink = memo(({ sourceIdx, device }: LinkProps) => {
     }
 
     const definitionModel = definition.model !== device.model_id ? ` (${definition.model})` : "";
-    const definitionVersion = definition.version ? ` (\`v${definition.version}\`)` : "";
     const githubUrlParams = {
         template: "problem_report.yaml",
         title: `[${device.model_id}${definitionModel} / ${device.manufacturer}] ???`,
@@ -103,7 +102,7 @@ node: \`${bridgeInfo.os.node_version}\`
 ha: \`${bridgeInfo.config.homeassistant.enabled}\``,
         notes: `
 #### Device
-definition: \`${definition.model}\` - \`${definition.vendor}\`${definitionVersion}
+definition: \`${definition.model}\` - \`${definition.vendor}\` (\`v${definition.version ?? "0.0.0"}\`)
 software_build_id: \`${device.software_build_id}\`
 date_code: \`${device.date_code}\`
 endpoints:


### PR DESCRIPTION
When browsing Z2M issues, all I see is gibberish Tuya IDs: `_TZ3000_cjrngdr3`.
(to be fair I have memorized a lot of them 😅)

I need something to recognize the devices (if they are supported - the converter name is recognizable).
> [TS0001 / _TZ3000_iktiy8ue] ???
> [TS0001 / _TZ3000_iktiy8ue] (B5Z) ???

We can further improve this.
If device is unsupported, change 'Report problem' to 'Request support', with the appropriate issue template.
Should I do that as well?