### PR TITLE
fix: use sRGB for color picker XY conversions, add XY sliders for color_xy devices

### DIFF
--- a/src/components/editors/ColorEditor.tsx
+++ b/src/components/editors/ColorEditor.tsx
@@ -18,10 +18,13 @@ import {
     convertRgbToString,
     convertStringToColor,
     convertToColor,
+    convertXyToRgb,
     convertXyYToString,
+    SRGB,
     SUPPORTED_GAMUTS,
     type ZigbeeColor,
 } from "./index.js";
+import clamp from "lodash/clamp.js";
 
 type ColorEditorProps = Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> & {
     value: AnyColor;
@@ -157,42 +160,136 @@ const ColorEditor = memo(({ onChange, value: initialValue = {} as AnyColor, form
         onChange(convertFromColor(color, format));
     }, [color, format, onChange]);
 
+    const onXChange = useCallback(
+        (e: ChangeEvent<HTMLInputElement>) => {
+            if (e.target.value) {
+                const x = e.target.valueAsNumber;
+                const y = color.color_xy[1] || selectedGamut.white[1];
+                const newColor = convertToColor({ x, y }, "color_xy", selectedGamut);
+
+                setColor(newColor);
+                setColorString(convertColorToString(newColor));
+            }
+        },
+        [color.color_xy, selectedGamut],
+    );
+
+    const onYChange = useCallback(
+        (e: ChangeEvent<HTMLInputElement>) => {
+            if (e.target.value) {
+                const x = color.color_xy[0] || selectedGamut.white[0];
+                const y = e.target.valueAsNumber;
+                const newColor = convertToColor({ x, y }, "color_xy", selectedGamut);
+
+                setColor(newColor);
+                setColorString(convertColorToString(newColor));
+            }
+        },
+        [color.color_xy, selectedGamut],
+    );
+
     const hueBackgroundColor = useMemo(() => `hsl(${color.color_hs[0]}, 100%, 50%)`, [color.color_hs[0]]);
+
+    // Generate gradient backgrounds for XY sliders by sampling colors along each axis
+    const xGradientBackground = useMemo(() => {
+        const y = color.color_xy[1] || selectedGamut.white[1];
+        const stops = Array.from({ length: 8 }, (_, i) => {
+            const x = (i / 7) * 0.74;
+            const rgb = convertXyToRgb(x, y, undefined, SRGB);
+            return `rgb(${clamp(rgb[0], 0, 255)}, ${clamp(rgb[1], 0, 255)}, ${clamp(rgb[2], 0, 255)})`;
+        });
+
+        return `linear-gradient(to right, ${stops.join(", ")})`;
+    }, [color.color_xy[1], selectedGamut]);
+
+    const yGradientBackground = useMemo(() => {
+        const x = color.color_xy[0] || selectedGamut.white[0];
+        const stops = Array.from({ length: 8 }, (_, i) => {
+            const y = (i / 7) * 0.84;
+            const rgb = convertXyToRgb(x, y > 0 ? y : 0.001, undefined, SRGB);
+            return `rgb(${clamp(rgb[0], 0, 255)}, ${clamp(rgb[1], 0, 255)}, ${clamp(rgb[2], 0, 255)})`;
+        });
+
+        return `linear-gradient(to right, ${stops.join(", ")})`;
+    }, [color.color_xy[0], selectedGamut]);
 
     return (
         <>
-            <div className="flex flex-row flex-wrap gap-3 items-center">
-                <div className={`w-full${minimal ? " max-w-xs" : ""}`}>
-                    <input
-                        type="range"
-                        min={0}
-                        max={100}
-                        value={color.color_hs[1]}
-                        className={`range [--range-bg:transparent] [--range-fill:0] w-full${minimal ? " range-xs " : ""}`}
-                        style={{ backgroundImage: SATURATION_BACKGROUND_IMAGE, backgroundColor: hueBackgroundColor }}
-                        onChange={onSaturationChange}
-                        onTouchEnd={onRangeSubmit}
-                        onMouseUp={onRangeSubmit}
-                        onKeyUp={onRangeSubmit}
-                    />
-                </div>
-            </div>
-            <div className="flex flex-row flex-wrap gap-3 items-center">
-                <div className={`w-full${minimal ? " max-w-xs" : ""}`}>
-                    <input
-                        type="range"
-                        min={0}
-                        max={360}
-                        value={color.color_hs[0]}
-                        className={`range [--range-bg:transparent] [--range-fill:0] w-full${minimal ? " range-xs " : ""}`}
-                        style={{ backgroundImage: HUE_BACKGROUND_IMAGE }}
-                        onChange={onHueChange}
-                        onTouchEnd={onRangeSubmit}
-                        onMouseUp={onRangeSubmit}
-                        onKeyUp={onRangeSubmit}
-                    />
-                </div>
-            </div>
+            {format === "color_xy" ? (
+                <>
+                    <div className="flex flex-row flex-wrap gap-3 items-center">
+                        <span className="text-xs w-4">X</span>
+                        <div className={`grow${minimal ? " max-w-xs" : ""}`}>
+                            <input
+                                type="range"
+                                min={0}
+                                max={0.74}
+                                step={0.001}
+                                value={color.color_xy[0]}
+                                className={`range [--range-bg:transparent] [--range-fill:0] w-full${minimal ? " range-xs " : ""}`}
+                                style={{ backgroundImage: xGradientBackground }}
+                                onChange={onXChange}
+                                onTouchEnd={onRangeSubmit}
+                                onMouseUp={onRangeSubmit}
+                                onKeyUp={onRangeSubmit}
+                            />
+                        </div>
+                    </div>
+                    <div className="flex flex-row flex-wrap gap-3 items-center">
+                        <span className="text-xs w-4">Y</span>
+                        <div className={`grow${minimal ? " max-w-xs" : ""}`}>
+                            <input
+                                type="range"
+                                min={0}
+                                max={0.84}
+                                step={0.001}
+                                value={color.color_xy[1]}
+                                className={`range [--range-bg:transparent] [--range-fill:0] w-full${minimal ? " range-xs " : ""}`}
+                                style={{ backgroundImage: yGradientBackground }}
+                                onChange={onYChange}
+                                onTouchEnd={onRangeSubmit}
+                                onMouseUp={onRangeSubmit}
+                                onKeyUp={onRangeSubmit}
+                            />
+                        </div>
+                    </div>
+                </>
+            ) : (
+                <>
+                    <div className="flex flex-row flex-wrap gap-3 items-center">
+                        <div className={`w-full${minimal ? " max-w-xs" : ""}`}>
+                            <input
+                                type="range"
+                                min={0}
+                                max={100}
+                                value={color.color_hs[1]}
+                                className={`range [--range-bg:transparent] [--range-fill:0] w-full${minimal ? " range-xs " : ""}`}
+                                style={{ backgroundImage: SATURATION_BACKGROUND_IMAGE, backgroundColor: hueBackgroundColor }}
+                                onChange={onSaturationChange}
+                                onTouchEnd={onRangeSubmit}
+                                onMouseUp={onRangeSubmit}
+                                onKeyUp={onRangeSubmit}
+                            />
+                        </div>
+                    </div>
+                    <div className="flex flex-row flex-wrap gap-3 items-center">
+                        <div className={`w-full${minimal ? " max-w-xs" : ""}`}>
+                            <input
+                                type="range"
+                                min={0}
+                                max={360}
+                                value={color.color_hs[0]}
+                                className={`range [--range-bg:transparent] [--range-fill:0] w-full${minimal ? " range-xs " : ""}`}
+                                style={{ backgroundImage: HUE_BACKGROUND_IMAGE }}
+                                onChange={onHueChange}
+                                onTouchEnd={onRangeSubmit}
+                                onMouseUp={onRangeSubmit}
+                                onKeyUp={onRangeSubmit}
+                            />
+                        </div>
+                    </div>
+                </>
+            )}
             {!minimal && (
                 <div className="flex flex-row flex-wrap gap-2 justify-around">
                     <ColorInput label="hex" name="hex" value={colorString.hex} onChange={onInputChange} onFocus={onInputFocus} onBlur={onInputBlur} />

--- a/src/components/editors/index.ts
+++ b/src/components/editors/index.ts
@@ -123,6 +123,22 @@ const GAMMA_CORRECTION_LINEAR: Readonly<GammaCorrection> = {
 
 const GAMMA_CORRECTION_SRGB = makeGammaCorrection({ threshold: 0.0031308, slope: 12.92, exponent: 2.4, offset: 0.055 });
 
+/**
+ * sRGB gamut — the standard color space for web displays.
+ * All HSV/RGB/hex values shown on screen are in sRGB, so conversions between
+ * these display formats and CIE XY must use sRGB primaries. Using a device-specific
+ * gamut (e.g. Philips Hue) for this conversion produces incorrect XY coordinates
+ * because the device has different primaries than the screen.
+ */
+export const SRGB: Readonly<Gamut> = {
+    name: "sRGB",
+    red: [0.64, 0.33],
+    green: [0.3, 0.6],
+    blue: [0.15, 0.06],
+    white: [0.3127, 0.329],
+    gammaCorrection: GAMMA_CORRECTION_SRGB,
+};
+
 /** https://en.wikipedia.org/wiki/CIE_1931_color_space */
 const CIE1931: Readonly<Gamut> = {
     name: "Zigbee / CIE 1931",
@@ -164,6 +180,8 @@ for (const key in SUPPORTED_GAMUTS) {
 
     gamutMatrices[entry.name] = buildMatrices(entry);
 }
+
+gamutMatrices[SRGB.name] = buildMatrices(SRGB);
 
 /**
  * Use vendor and description from device definition to determine the proper gamut.
@@ -322,10 +340,16 @@ export const convertHexToRgb = (hex: string): Vector3 => {
 };
 
 export const convertToColor = (source: AnyColor, sourceFormat: ColorFormat, gamut: Gamut): ZigbeeColor => {
+    // All RGB/HSV/hex values are in sRGB (the web display standard).
+    // Conversions between these display formats and CIE XY must use sRGB primaries,
+    // not the device gamut, because the user sees sRGB colors on their screen.
+    // The device maps CIE XY to its own gamut internally.
+    const displayGamut = SRGB;
+
     switch (sourceFormat) {
         case "color_xy": {
-            const { x = gamut.white[0], y = gamut.white[1], Y = findMaximumY(x, y === 0 ? gamut.white[1] : y, gamut, 10) } = source as XYColor;
-            const rgb = y === 0 ? ([255, 255, 255] as Vector3) : convertXyToRgb(x, y, Y, gamut);
+            const { x = gamut.white[0], y = gamut.white[1], Y = findMaximumY(x, y === 0 ? gamut.white[1] : y, displayGamut, 10) } = source as XYColor;
+            const rgb = y === 0 ? ([255, 255, 255] as Vector3) : convertXyToRgb(x, y, Y, displayGamut);
 
             return {
                 color_rgb: rgb,
@@ -342,7 +366,7 @@ export const convertToColor = (source: AnyColor, sourceFormat: ColorFormat, gamu
             return {
                 color_rgb: rgb,
                 color_hs: [hue, saturation, value],
-                color_xy: convertRgbToXyY(...rgb, gamut),
+                color_xy: convertRgbToXyY(...rgb, displayGamut),
                 hex: convertRgbToHex(...rgb),
             };
         }
@@ -353,7 +377,7 @@ export const convertToColor = (source: AnyColor, sourceFormat: ColorFormat, gamu
             return {
                 color_rgb: [r, g, b],
                 color_hs: convertRgbToHsv(r, g, b),
-                color_xy: convertRgbToXyY(r, g, b, gamut),
+                color_xy: convertRgbToXyY(r, g, b, displayGamut),
                 hex: convertRgbToHex(r, g, b),
             };
         }
@@ -365,7 +389,7 @@ export const convertToColor = (source: AnyColor, sourceFormat: ColorFormat, gamu
             return {
                 color_rgb: rgb,
                 color_hs: convertRgbToHsv(...rgb),
-                color_xy: convertRgbToXyY(...rgb, gamut),
+                color_xy: convertRgbToXyY(...rgb, displayGamut),
                 hex,
             };
         }
@@ -376,7 +400,7 @@ export const convertToColor = (source: AnyColor, sourceFormat: ColorFormat, gamu
             return {
                 color_rgb: rgb,
                 color_hs: convertRgbToHsv(...rgb),
-                color_xy: convertRgbToXyY(...rgb, gamut),
+                color_xy: convertRgbToXyY(...rgb, displayGamut),
                 hex: convertRgbToHex(...rgb),
             };
         }


### PR DESCRIPTION
Fixes #367.

(thanks claude!)

### Problem

The color editor converts RGB/HSV values to CIE XY using the device gamut (e.g. Philips Hue) instead of sRGB. Since the user's screen displays sRGB, the color they pick doesn't match the XY coordinates sent to the device. E.g., selecting a saturated cyan (#00FFCC) on a Philips Hue device produces XY ≈ (0.343, 0.387), which is near white, instead of the correct XY ≈ (0.243, 0.396).

### Why sRGB, not the device gamut

RGB/HSV/hex values are always sRGB; that's what web displays render. Converting these to CIE XY must use sRGB primaries so that what the user sees on screen corresponds to what the device produces. The device firmware handles mapping CIE XY to its own physical gamut internally. Using the device gamut for this conversion effectively treats sRGB colors as if they were in the device's color space, producing wrong coordinates.

This is also the reason Koenkk/zigbee-herdsman-converters#11263 produces incorrect results for non-CIE1931 gamuts — it uses the device gamut for the RGB→XY conversion in the backend converters.

### Changes

**`src/components/editors/index.ts`:**
- Add `SRGB` gamut definition (standard web display primaries, D65 white, sRGB gamma)
- `convertToColor` now uses sRGB for all RGB/HSV/hex ↔ XY conversions

**`src/components/editors/ColorEditor.tsx`:**
- For `color_xy` format: show X and Y sliders (0–0.74 and 0–0.84) with live gradient backgrounds, instead of hue/saturation sliders
- For `color_hs` format: existing hue/saturation sliders unchanged