### PR TITLE
fix: add `70b3d5` OUI

### DIFF
--- a/src/oui.ts
+++ b/src/oui.ts
@@ -531,6 +531,7 @@ export const OUI = new Map([
     ["708976", "Tuya Smart Inc."],
     ["70ac08", "Silicon Laboratories"],
     ["70af09", "Espressif Inc."],
+    ["70b3d5", "IEEE Registration Authority"],
     ["70b8f6", "Espressif Inc."],
     ["70b950", "Texas Instruments"],
     ["70c59c", "Silicon Laboratories"],


### PR DESCRIPTION
- fixes https://github.com/Koenkk/zigbee2mqtt/issues/31363

Strange address: `70b3d52b600fcf89` - needs more digits than usual

- [csv](https://standards-oui.ieee.org/): 70B3D5 IEEE Registration Authority
- [Wireshark](https://www.wireshark.org/tools/oui-lookup.html): `70:B3:D5:2B:60:00/36` HLT Micro
  - if you search just `70b3d5`, you get more OUIs of this format
- [mac lookup](https://maclookup.app/macaddress/70b3d52b6): `70:B3:D5:2B:6` HLT Micro

I saw it before, don't remember where.. It's Silicon Labs EFR32MG1 from Tuya, if I recall correctly.