### PR TITLE
fix: improve device description

### DIFF
--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -280,7 +280,7 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                     </span>
                 </div>
                 <div>
-                    {device.description || ""}
+                    <p className="text-wrap break-all text-base-content/70">{device.description || ""}</p>
                     <DeviceControlUpdateDesc device={device} setDeviceDescription={setDeviceDescription} />
                 </div>
                 <div className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-2 text-wrap">

--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -280,7 +280,7 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                     </span>
                 </div>
                 <div>
-                    <pre className="inline text-wrap break-all">{device.description || ""}</pre>
+                    {device.description || ""}
                     <DeviceControlUpdateDesc device={device} setDeviceDescription={setDeviceDescription} />
                 </div>
                 <div className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-2 text-wrap">


### PR DESCRIPTION
I feel this looks a little better?

<img width="60%" alt="before" src="https://github.com/user-attachments/assets/f734af0b-dc4f-403a-ba4c-0dda10123c46" />

<img width="60%" alt="after" src="https://github.com/user-attachments/assets/abbe3c64-68b5-4206-adb8-41857737a4d6" />
