### PR TITLE
fix: avoid unwanted horizontal scroll in Docs tab

### DIFF
--- a/src/components/device-page/tabs/Docs.tsx
+++ b/src/components/device-page/tabs/Docs.tsx
@@ -552,11 +552,11 @@ const Docs = memo(({ sourceIdx, definitionModel }: DocsProps) => {
             >
                 <DocsContent docsPromise={docsPromise} />
                 <div className="divider" />
-                <div className="flex flex-row flex-wrap items-center gap-1 mt-3">
+                <div className="flex flex-row flex-wrap items-center gap-1 mt-3 text-wrap break-all">
                     Source:
                     <span>{url}</span>
                 </div>
-                <div className="flex flex-row flex-wrap items-center gap-1">
+                <div className="flex flex-row flex-wrap items-center gap-1 text-wrap break-all">
                     Edit:
                     <a href={editUrl} className="link link-primary" target="_blank" rel="noopener noreferrer">
                         {editUrl} <FontAwesomeIcon icon={faArrowUpRightFromSquare} />


### PR DESCRIPTION
Source and edit links are too long, causing unnecessary horizontal scroll.

https://github.com/user-attachments/assets/edf2609e-4fa7-415b-b5cd-dac381160b8a

Fix:

<img width="60%"  src="https://github.com/user-attachments/assets/3d853ae6-fbb9-40ff-97c9-3b7ca50bfce9" />
