### PR TITLE
fix: better wrapping in device definition description

### DIFF
--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -337,8 +337,8 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                             {device.definition?.version && device.definition.version !== "0.0.0" ? ` (v${device.definition.version})` : null}
                         </p>
                         <p className="text-base-content/50">
-                            {definitionDescription} (
-                            <VendorLink supported={device.supported} definitionVendor={device.definition?.vendor} icon />)
+                            {definitionDescription}{" "}
+                            <VendorLink supported={device.supported} definitionVendor={device.definition?.vendor} icon brackets />
                         </p>
                     </div>
                     {device.software_build_id ? (

--- a/src/components/value-decorators/VendorLink.tsx
+++ b/src/components/value-decorators/VendorLink.tsx
@@ -10,9 +10,10 @@ type VendorLinkProps = {
     supported: Device["supported"];
     definitionVendor?: NonNullable<Device["definition"]>["vendor"];
     icon?: boolean;
+    brackets?: boolean;
 };
 
-const VendorLink = memo(({ supported, definitionVendor, icon = false }: VendorLinkProps) => {
+const VendorLink = memo(({ supported, definitionVendor, icon = false, brackets = false }: VendorLinkProps) => {
     const { t } = useTranslation("zigbee");
     let label = t(($) => $.unsupported);
     let url = SUPPORT_NEW_DEVICES_DOCS_URL;
@@ -24,8 +25,13 @@ const VendorLink = memo(({ supported, definitionVendor, icon = false }: VendorLi
 
     return (
         <Link target="_blank" rel="noopener noreferrer" to={url} className="link link-hover">
-            {label}
-            {icon ? <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="ms-0.5" /> : null}
+            {brackets && "("}
+            {label.split(" ").slice(0, -1).join(" ")}
+            <span className="whitespace-nowrap">
+                {label.split(" ").slice(-1)[0]}
+                {icon && <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="ms-0.5" />}
+                {brackets && ")"}
+            </span>
         </Link>
     );
 });


### PR DESCRIPTION
Link icon behaves as a breaking character. Meaning a new line could occur around it:

Before:
```
lightbulb (IKEA of Sweden🔗)

lightbulb (IKEA of Sweden🔗
)

lightbulb (IKEA of Sweden
🔗)
```

After:
```
lightbulb (IKEA of Sweden🔗)

lightbulb (IKEA of
Sweden🔗)
```

Pics:

<img width="40%" src="https://github.com/user-attachments/assets/343122c1-e683-490a-a33e-d0c6092a577b" />
<img width="40%" src="https://github.com/user-attachments/assets/2b0bab32-6640-4a9e-bbdb-275fd83a59b0" />

PS
Have you also considered a simpler character instead of the svg icon? 
Like this: ↗ (although it looks like windfront renders it as an emoji ↗️ ??)