### PR TITLE
fix: replace external link icon for better wrapping

### DIFF
--- a/src/components/device-page/tabs/Docs.tsx
+++ b/src/components/device-page/tabs/Docs.tsx
@@ -1,9 +1,8 @@
-import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { memo, type ReactNode, Suspense, use } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "../../../store.js";
 import { normalizeDefinitionModel } from "../../../utils.js";
+import ExternalIcon from "../../value-decorators/ExternalIcon.js";
 
 type DocsProps = {
     sourceIdx: number;
@@ -102,7 +101,8 @@ const parseMarkdownLinks = (segment: string, keyPrefix: string): ReactNode[] => 
         } else {
             nodes.push(
                 <a key={`${keyPrefix}-link-${matchStartIndex}`} href={href} className="link link-primary" target="_blank" rel="noopener noreferrer">
-                    {linkText} <FontAwesomeIcon icon={faArrowUpRightFromSquare} />
+                    {linkText}
+                    <ExternalIcon />
                 </a>,
             );
         }
@@ -559,7 +559,8 @@ const Docs = memo(({ sourceIdx, definitionModel }: DocsProps) => {
                 <div className="flex flex-row flex-wrap items-center gap-1 text-wrap break-all">
                     Edit:
                     <a href={editUrl} className="link link-primary" target="_blank" rel="noopener noreferrer">
-                        {editUrl} <FontAwesomeIcon icon={faArrowUpRightFromSquare} />
+                        {editUrl}
+                        <ExternalIcon />
                     </a>
                 </div>
             </Suspense>

--- a/src/components/value-decorators/DefinitionLink.tsx
+++ b/src/components/value-decorators/DefinitionLink.tsx
@@ -1,11 +1,10 @@
-import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { SUPPORT_NEW_DEVICES_DOCS_URL } from "../../consts.js";
 import type { Device } from "../../types.js";
 import { normalizeDefinitionModel } from "../../utils.js";
+import ExternalIcon from "./ExternalIcon.js";
 
 type DefinitionLinkProps = {
     modelId: Device["model_id"];
@@ -27,7 +26,7 @@ const DefinitionLink = memo(({ modelId, supported, definitionModel, icon = false
     return (
         <Link target="_blank" rel="noopener noreferrer" to={url} className="link link-hover">
             {label}
-            {icon ? <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="ms-0.5" /> : null}
+            {icon ? <ExternalIcon /> : null}
         </Link>
     );
 });

--- a/src/components/value-decorators/ExternalIcon.tsx
+++ b/src/components/value-decorators/ExternalIcon.tsx
@@ -1,0 +1,8 @@
+const ExternalIcon = () => (
+    <span className="select-none opacity-80 ml-0.5 mr-0.5" aria-hidden="true">
+        {"\u2197\uFE0E"}
+    </span>
+);
+// north east arrow ↗ + text variation selector
+
+export default ExternalIcon;

--- a/src/components/value-decorators/VendorLink.tsx
+++ b/src/components/value-decorators/VendorLink.tsx
@@ -1,10 +1,9 @@
-import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import { SUPPORT_NEW_DEVICES_DOCS_URL } from "../../consts.js";
 import type { Device } from "../../types.js";
+import ExternalIcon from "./ExternalIcon.js";
 
 type VendorLinkProps = {
     supported: Device["supported"];
@@ -25,7 +24,7 @@ const VendorLink = memo(({ supported, definitionVendor, icon = false }: VendorLi
     return (
         <Link target="_blank" rel="noopener noreferrer" to={url} className="link link-hover">
             {label}
-            {icon ? <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="ms-0.5" /> : null}
+            {icon ? <ExternalIcon /> : null}
         </Link>
     );
 });


### PR DESCRIPTION
Please Nerivec I can't stand the poor wrapping 🙏🏻 

<img width="40%" alt="Screenshot From 2026-04-10 21-21-27" src="https://github.com/user-attachments/assets/d2918b6a-3534-4931-96fc-5e12686a27b2" />
<img width="40%" alt="Screenshot From 2026-04-10 21-21-25" src="https://github.com/user-attachments/assets/97b13651-135d-4fc3-ab06-fb1cda80e950" />
<p></p>

Before adding the link icon, wrapping was good.

But the svg acts as a breaking character and screws it up.

The alternative to the complicated logic is a text icon. This one won't break