### PR TITLE
fix: improve codeblocks display

### DIFF
--- a/src/components/device-page/tabs/Docs.tsx
+++ b/src/components/device-page/tabs/Docs.tsx
@@ -102,7 +102,8 @@ const parseMarkdownLinks = (segment: string, keyPrefix: string): ReactNode[] => 
         } else {
             nodes.push(
                 <a key={`${keyPrefix}-link-${matchStartIndex}`} href={href} className="link link-primary" target="_blank" rel="noopener noreferrer">
-                    {linkText} <FontAwesomeIcon icon={faArrowUpRightFromSquare} />
+                    {linkText}
+                    <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="ms-0.5" />
                 </a>,
             );
         }
@@ -559,7 +560,8 @@ const Docs = memo(({ sourceIdx, definitionModel }: DocsProps) => {
                 <div className="flex flex-row flex-wrap items-center gap-1 text-wrap break-all">
                     Edit:
                     <a href={editUrl} className="link link-primary" target="_blank" rel="noopener noreferrer">
-                        {editUrl} <FontAwesomeIcon icon={faArrowUpRightFromSquare} />
+                        {editUrl}
+                        <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="ms-0.5" />
                     </a>
                 </div>
             </Suspense>

--- a/src/components/device-page/tabs/Docs.tsx
+++ b/src/components/device-page/tabs/Docs.tsx
@@ -141,9 +141,9 @@ function parseMarkdownInline(md: string): ReactNode[] {
 
         if (inlineCode !== undefined) {
             parsedLine.push(
-                <span key={`md-code-${matchStartIndex}`} className="badge badge-ghost font-mono">
+                <code key={`md-code-${matchStartIndex}`} className="bg-base-200 text-base-content/80 py-1 px-3 rounded-box">
                     {inlineCode}
-                </span>,
+                </code>,
             );
         } else if (boldItalicText !== undefined) {
             parsedLine.push(
@@ -485,7 +485,7 @@ function parseMarkdown(md: string): ReactNode[] {
         if (line.startsWith("```")) {
             if (inCodeBlock) {
                 outputNodes.push(
-                    <pre key={`md-block-${blockIdx++}`} className="w-full bg-base-200 my-1 py-2 px-4 rounded-sm overflow-x-auto">
+                    <pre key={`md-block-${blockIdx++}`} className="w-full bg-base-200 text-base-content/80 my-1 py-2 px-4 rounded-sm overflow-x-auto">
                         <code>{codeBlock.join("\n")}</code>
                     </pre>,
                 );


### PR DESCRIPTION
Improves readability a bit

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/debf5f06-18c5-420e-bcf4-c6f71f2ef21b" />

---

Also found an error, inline code inside link is broken. 
Should we fix, or remove them from the docs? 
([Hue](https://www.zigbee2mqtt.io/devices/9290024896.html#power-on-behavior), [Xiaomi](https://www.zigbee2mqtt.io/devices/GZCGQ01LM.html#adapter-firmware))

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/d9898fc0-ce6c-4a22-b561-5f3344e4f4fc" />
 