### PR TITLE
fix: transmit power description

### DIFF
--- a/mocks/bridgeInfo.ts
+++ b/mocks/bridgeInfo.ts
@@ -1017,8 +1017,7 @@ export const BRIDGE_INFO: Message<Zigbee2MQTTAPI["bridge/info"]> = {
                             requiresRestart: true,
                             minimum: -128,
                             maximum: 127,
-                            description:
-                                "Transmit power of adapter, only available for Z-Stack (CC253*/CC2652/CC1352) adapters, CC2652 = 5dbm, CC1352 max is = 20dbm (5dbm default)",
+                            description: "Transmit power of adapter (5dBm default)",
                         },
                         output: {
                             type: "string",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -407,7 +407,7 @@
         "advanced-output": "Examples when 'state' of a device is published json: topic: 'zigbee2mqtt/my_bulb' payload '{\"state\": \"ON\"}' attribute: topic 'zigbee2mqtt/my_bulb/state' payload 'ON' attribute_and_json: both json and attribute (see above)",
         "advanced-pan_id": "Zigbee pan ID, changing requires re-pairing all devices!",
         "advanced-timestamp_format": "Log timestamp format (see https://github.com/taylorhakes/fecha?tab=readme-ov-file#formatting-tokens for all supported tokens)",
-        "advanced-transmit_power": "Transmit power of adapter, only available for Z-Stack (CC253*/CC2652/CC1352) adapters, CC2652 = 5dbm, CC1352 max is = 20dbm (5dbm default)",
+        "advanced-transmit_power": "Transmit power of adapter (5dBm default)",
         "availability": "Checks whether devices are online/offline",
         "availability-active": "Options for active devices (routers/mains powered)",
         "availability-active-backoff": "Enable timeout backoff on failed availability pings (x1.5, x3, x6, x12...)",


### PR DESCRIPTION
Must also update Z2M and Z2M docs.

I think the max examples can stay only in docs. Wanna add more info here?