### PR TITLE
fix: icons for Tuya vibration sensor

### DIFF
--- a/src/components/features/index.tsx
+++ b/src/components/features/index.tsx
@@ -710,12 +710,8 @@ export const getFeatureIcon = (name: string, value: unknown, unit?: unknown): [I
             break;
         }
         case "silence_mode": {
-            switch (value) {
-                case "ON": {
-                    icon = faVolumeXmark;
-
-                    break;
-                }
+            if (value === "ON") {
+                icon = faVolumeXmark;
             }
 
             break;

--- a/src/components/features/index.tsx
+++ b/src/components/features/index.tsx
@@ -342,6 +342,7 @@ const ICON_MAP: Record<string, IconDefinition> = {
     play_voice: faVolumeHigh,
     pulse_command: faVolumeHigh,
     squawk: faVolumeHigh,
+    silence_mode: faVolumeHigh,
     siren_and_light: faBell,
     sound: faVolumeUp,
 
@@ -351,6 +352,7 @@ const ICON_MAP: Record<string, IconDefinition> = {
     broadcast_alarm: faTriangleExclamation,
     linkage_alarm: faTriangleExclamation,
     alarm: faTriangleExclamation,
+    alarm_status: faTriangleExclamation,
     alert_behaviour: faTriangleExclamation,
     warning: faTriangleExclamation,
     clear_fault: faCircleCheck,
@@ -699,6 +701,17 @@ export const getFeatureIcon = (name: string, value: unknown, unit?: unknown): [I
                 case "mute":
                 case "muted":
                 case "OFF": {
+                    icon = faVolumeXmark;
+
+                    break;
+                }
+            }
+
+            break;
+        }
+        case "silence_mode": {
+            switch (value) {
+                case "ON": {
                     icon = faVolumeXmark;
 
                     break;


### PR DESCRIPTION
Some icons for [TS0601_vibration_alarm_sensor](https://github.com/Koenkk/zigbee-herdsman-converters/blob/24bb7d6131f26a2753484ea3b053274af2fe107b/src/devices/lincukoo.ts#L390).

Is it ok to keep adding icons here?
It's quite annoying that everyone names exposes however they want.. and we end up with multiple names for the same features.