### PR TITLE
fix: add icons for Tuya circuit breaker

### DIFF
--- a/src/components/features/index.tsx
+++ b/src/components/features/index.tsx
@@ -24,6 +24,7 @@ import {
     faCloudShowersHeavy,
     faCloudSunRain,
     faCog,
+    faCoins,
     faCompass,
     faCube,
     faDatabase,
@@ -43,6 +44,7 @@ import {
     faGaugeHigh,
     faGear,
     faGraduationCap,
+    faHandHoldingDollar,
     faHandPointUp,
     faHashtag,
     faHeartPulse,
@@ -71,12 +73,14 @@ import {
     faPlane,
     faPlay,
     faPlugCircleXmark,
+    faPlus,
     faPowerOff,
     faRadiation,
     faRadiationAlt,
     faRainbow,
     faRecycle,
     faRotate,
+    faRotateLeft,
     faRuler,
     faSeedling,
     faShieldHalved,
@@ -151,10 +155,12 @@ const ICON_MAP: Record<string, IconDefinition> = {
     overpower: faBolt,
     overcurrent: faBolt,
     current: faBolt,
+    leakage_current: faBolt,
     reactive_energy: faBolt,
     signed_power: faBolt,
     power: faBolt,
     energy: faBolt,
+    energy_produced: faBolt,
     watt: faBolt,
     frequency: faWaveSquare,
     power_factor: faIndustry,
@@ -354,10 +360,14 @@ const ICON_MAP: Record<string, IconDefinition> = {
     linkage_alarm: faTriangleExclamation,
     alarm: faTriangleExclamation,
     alarm_status: faTriangleExclamation,
+    alarm_set_1: faTriangleExclamation,
+    alarm_set_2: faTriangleExclamation,
+    alarm_set_3: faTriangleExclamation,
     alert_behaviour: faTriangleExclamation,
     warning: faTriangleExclamation,
     clear_fault: faCircleCheck,
     fault: faCircleExclamation,
+    faults: faCircleExclamation,
     error: faCircleExclamation,
     breaker: faCircleExclamation,
     trouble: faCircleExclamation,
@@ -372,6 +382,7 @@ const ICON_MAP: Record<string, IconDefinition> = {
     restore_default: faPowerOff,
     reset_switch: faPowerOff,
     powerup_status: faPowerOff,
+    power_on_behavior: faPowerOff,
     status: faCircleInfo,
     state: faStarHalfAlt,
     enabled: faCircleCheck,
@@ -464,11 +475,18 @@ const ICON_MAP: Record<string, IconDefinition> = {
     region: faMap,
     sub_region: faMap,
 
-    // Contracts / production
+    // Contracts / production / expenses
     contract: faFileContract,
     contract_type: faFileContract,
     production: faIndustry,
     producer: faIndustry,
+    prepayment: faHandHoldingDollar,
+    energy_balance: faCoins,
+
+    // Operations
+    energy_balance_add: faPlus,
+    energy_balance_reset: faRotateLeft,
+    water_total_reset: faRotateLeft,
 
     // Generic descriptors
     model: faTag,
@@ -639,6 +657,13 @@ export const getFeatureIcon = (name: string, value: unknown, unit?: unknown): [I
         case "water_leak":
         case "tamper": {
             if (value) {
+                className = "text-error";
+            }
+
+            break;
+        }
+        case "faults": {
+            if (Array.isArray(value) && (value as string[]).length > 0) {
                 className = "text-error";
             }
 

--- a/src/components/features/index.tsx
+++ b/src/components/features/index.tsx
@@ -160,7 +160,8 @@ const ICON_MAP: Record<string, IconDefinition> = {
     power_factor: faIndustry,
 
     // Temperature / climate
-    // cpu_temperature: faTemperatureHigh, // customized in fn
+    cpu_temperature: faThermometerThreeQuarters,
+    device_temperature: faThermometerThreeQuarters,
     heating_stop: faTemperatureHigh,
     heat_protect: faTemperatureHigh,
     warm_floor: faTemperatureHigh,
@@ -643,8 +644,6 @@ export const getFeatureIcon = (name: string, value: unknown, unit?: unknown): [I
 
             break;
         }
-        case "cpu_temperature":
-        case "device_temperature":
         case "temperature":
         case "local_temperature": {
             [icon, className] = getTemperatureIcon(value as number, unit as TemperatureUnit);

--- a/src/components/features/index.tsx
+++ b/src/components/features/index.tsx
@@ -663,7 +663,7 @@ export const getFeatureIcon = (name: string, value: unknown, unit?: unknown): [I
             break;
         }
         case "faults": {
-            if (Array.isArray(value) && (value as string[]).length > 0) {
+            if (Array.isArray(value) && value.length > 0) {
                 className = "text-error";
             }
 

--- a/src/components/value-decorators/DisplayValue.tsx
+++ b/src/components/value-decorators/DisplayValue.tsx
@@ -47,6 +47,17 @@ const BooleanValueView = memo((props: DisplayValueProps) => {
     }
 });
 
+const ArrayValueView = memo((props: DisplayValueProps) => {
+    const { value, name } = props;
+    const { t } = useTranslation("values");
+
+    if (name === "faults") {
+        return (value as string[]).length > 0 ? <span className="text-error animate-pulse">{String(value)}</span> : t(($) => $.clear);
+    }
+
+    return String(value);
+});
+
 const DisplayValue = memo((props: DisplayValueProps) => {
     const { t } = useTranslation("values");
     const { value } = props;
@@ -57,6 +68,7 @@ const DisplayValue = memo((props: DisplayValueProps) => {
         case "undefined":
             return "N/A";
         case "object":
+            if (Array.isArray(value)) return <ArrayValueView {...props} />;
             return value === null ? t(($) => $.null) : JSON.stringify(value);
         case "string":
             return value === "" ? <span className="text-xs opacity-50">{t(($) => $.empty_string)}</span> : value;

--- a/src/components/value-decorators/DisplayValue.tsx
+++ b/src/components/value-decorators/DisplayValue.tsx
@@ -47,17 +47,6 @@ const BooleanValueView = memo((props: DisplayValueProps) => {
     }
 });
 
-const ArrayValueView = memo((props: DisplayValueProps) => {
-    const { value, name } = props;
-    const { t } = useTranslation("values");
-
-    if (name === "faults") {
-        return (value as string[]).length > 0 ? String(value) : t(($) => $.clear);
-    }
-
-    return String(value);
-});
-
 const DisplayValue = memo((props: DisplayValueProps) => {
     const { t } = useTranslation("values");
     const { value } = props;
@@ -68,7 +57,6 @@ const DisplayValue = memo((props: DisplayValueProps) => {
         case "undefined":
             return "N/A";
         case "object":
-            if (Array.isArray(value)) return <ArrayValueView {...props} />;
             return value === null ? t(($) => $.null) : JSON.stringify(value);
         case "string":
             return value === "" ? <span className="text-xs opacity-50">{t(($) => $.empty_string)}</span> : value;

--- a/src/components/value-decorators/DisplayValue.tsx
+++ b/src/components/value-decorators/DisplayValue.tsx
@@ -52,7 +52,7 @@ const ArrayValueView = memo((props: DisplayValueProps) => {
     const { t } = useTranslation("values");
 
     if (name === "faults") {
-        return (value as string[]).length > 0 ? <span className="text-error animate-pulse">{String(value)}</span> : t(($) => $.clear);
+        return (value as string[]).length > 0 ? String(value) : t(($) => $.clear);
     }
 
     return String(value);


### PR DESCRIPTION
<img width="30%"  alt="Screenshot From 2026-05-13 20-56-09" src="https://github.com/user-attachments/assets/12ef67b5-f233-4b75-b82f-58063b7212d1" />
<img width="70%" alt="Screenshot From 2026-05-13 20-55-29" src="https://github.com/user-attachments/assets/3b48a387-3ff8-468d-a615-5a03aca272aa" />
<p>

Do you know if we can contribute icons to font awesome? Would be nice to differentiate the electrical measurements, like in HA. But we only have the two bolts
<img width="40%" src="https://github.com/user-attachments/assets/e449a2a2-19c3-425a-ad17-f58c9bb2f4c6" />

