### PR TITLE
Improve supported display

### DIFF
--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -1,4 +1,4 @@
-import { faCheck, faCheckCircle, faCode, faExclamationTriangle, faSpinner, faSquareArrowUpRight } from "@fortawesome/free-solid-svg-icons";
+import { faCheckCircle, faCogs, faExclamationTriangle, faFileCode, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import snakeCase from "lodash/snakeCase.js";
 import { memo, useCallback, useMemo } from "react";
@@ -43,9 +43,9 @@ const SOURCE_BADGE_COLOR = {
     generated: "badge-accent",
 };
 const SOURCE_BADGE_ICON = {
-    native: faCheck,
-    external: faSquareArrowUpRight,
-    generated: faCode,
+    native: faCheckCircle,
+    external: faFileCode,
+    generated: faCogs,
 };
 
 const endpointsReplacer = (key: string, value: unknown) => {

--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -264,9 +264,10 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                 </h2>
                 <div className="flex flex-row flex-wrap gap-2">
                     <span className={`badge ${device.definition ? SOURCE_BADGE_COLOR[device.definition.source] : ""}`}>
-                        {t(($) => $.support, { ns: "common" })}:
+                        {t(($) => $.support, { ns: "common" })}
+                        {": "}
+                        {t(($) => (device.definition ? $[device.definition.source] : $.unsupported), { ns: "zigbee" }).toLowerCase()}
                         {device.definition ? <FontAwesomeIcon icon={SOURCE_BADGE_ICON[device.definition.source]} /> : null}
-                        {t(($) => (device.definition ? $[device.definition.source] : $.unsupported))}
                     </span>
                     {!device.supported && (
                         <span className="badge">

--- a/src/components/device/DeviceImage.tsx
+++ b/src/components/device/DeviceImage.tsx
@@ -1,4 +1,4 @@
-import { faBan, faCode, faExclamationTriangle, faSpinner, faSquareArrowUpRight, faSync } from "@fortawesome/free-solid-svg-icons";
+import { faBan, faCogs, faExclamationTriangle, faFileCode, faSpinner, faSync } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { memo, Suspense, useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -32,11 +32,11 @@ const DeviceImage = memo((props: Readonly<DeviceImageProps>) => {
                 </span>
             ) : device.definition?.source === "generated" ? (
                 <span title={`${t(($) => $.support, { ns: "common" })}: ${t(($) => $[device.definition!.source])}`}>
-                    <FontAwesomeIcon icon={faCode} className="indicator-item indicator-bottom indicator-end text-accent" />
+                    <FontAwesomeIcon icon={faCogs} className="indicator-item indicator-bottom indicator-end text-accent" />
                 </span>
             ) : device.definition?.source === "external" ? (
                 <span title={`${t(($) => $.support, { ns: "common" })}: ${t(($) => $[device.definition!.source])}`}>
-                    <FontAwesomeIcon icon={faSquareArrowUpRight} className="indicator-item indicator-bottom indicator-end text-info" />
+                    <FontAwesomeIcon icon={faFileCode} className="indicator-item indicator-bottom indicator-end text-info" />
                 </span>
             ) : null,
         [device.interview_state, device.definition, t],

--- a/src/components/value-decorators/VendorLink.tsx
+++ b/src/components/value-decorators/VendorLink.tsx
@@ -14,12 +14,11 @@ type VendorLinkProps = {
 
 const VendorLink = memo(({ supported, definitionVendor, icon = false }: VendorLinkProps) => {
     const { t } = useTranslation("zigbee");
-    let label = t(($) => $.unsupported);
+    const label = definitionVendor || t(($) => $.unknown);
     let url = SUPPORT_NEW_DEVICES_DOCS_URL;
 
     if (supported && definitionVendor) {
         url = `https://www.zigbee2mqtt.io/supported-devices/#v=${encodeURIComponent(definitionVendor)}`;
-        label = definitionVendor;
     }
 
     return (


### PR DESCRIPTION
I think the code icons are more suggestive for external converters than generated definitions, so I changed them a bit:
<img width="292" height="335" alt="image" src="https://github.com/user-attachments/assets/58b41a68-f8f8-447d-918a-6734fc966288" />

Also shuffled the badge a little:
<img width="451" height="222" alt="image" src="https://github.com/user-attachments/assets/6c3c8cb3-209f-419f-b0ca-8d305c56b635" />
<img width="451" height="222" alt="image" src="https://github.com/user-attachments/assets/48d8f1bd-ae62-4a19-bc84-c665a8874f76" />
<img width="451" height="222" alt="image" src="https://github.com/user-attachments/assets/6d712b11-7d96-459c-9df2-cb08bc0271fc" />


And fixed this unsupported text:
<img width="451" height="222" alt="image" src="https://github.com/user-attachments/assets/9f3486a2-d4b0-48d0-9fe0-8529944ee9e0" />
<img width="456" height="251" alt="image" src="https://github.com/user-attachments/assets/80de0683-473d-490b-be09-199d02f113b3" />


