### PR TITLE
fix: fix "disable periodic reporting" label

### DIFF
--- a/src/components/device-page/ReportingRow.tsx
+++ b/src/components/device-page/ReportingRow.tsx
@@ -199,7 +199,7 @@ const ReportingRow = memo(
                             ) : null}
                             {!showOnlyApply && !stateRule.isNew ? (
                                 <ConfirmButton<void>
-                                    title={t(($) => $.reset, { ns: "common" })}
+                                    title={t(($) => $.disable_periodic, { ns: "common" })}
                                     className="btn btn-square btn-error btn-outline join-item"
                                     onClick={async () => {
                                         // disable periodic reporting


### PR DESCRIPTION
Fixes the "disable periodic reporting" label in Device -> Reporting. In Z2M -> Reporting it's already correct.
There were 2 Reset labels rightfully causing confusion 😄 

<img width="250" height="141" alt="image" src="https://github.com/user-attachments/assets/9b81c1d4-3299-4bad-bec4-342cabe55952" />

<img width="250" height="141" alt="image" src="https://github.com/user-attachments/assets/c6969c7f-5ebe-4d76-ac25-0e4a0493d256" />

---

But it still needs some work. I don't think "disable periodic reporting" should be a dedicated button. I don't like it.

For me it's more intuitive if we remove it, and instead make the "max rep interval" field optional.
No value provided means the user doesn't want periodic reporting, so it sends 0 (disabled) by default. This makes much more sense to me. The "min rep interval" is still useful to prevent spam, it doesn't have to be 0.

Additionally:
- "sync" must be called automatically, immediately after "reset to device default" - no idea how to handle this
- "sync" doesn't need the confirmation prompt, it doesn't change anything
- "sync" should be blue and separate, to match the styling in Exposes tab