### PR TITLE
feat: add vendor image lookup

### DIFF
--- a/src/components/device/LazyImage.tsx
+++ b/src/components/device/LazyImage.tsx
@@ -22,9 +22,7 @@ const LazyImage = memo(({ device = {} as Device, className }: Readonly<LazyImage
         srcList.push(...fromZ2MDocs);
     }
 
-    if (!fromZ2MDocs.includes(genericDevice)) {
-        srcList.push(genericDevice);
-    }
+    srcList.push(genericDevice);
 
     const { src } = useImage({ srcList });
 

--- a/src/components/device/LazyImage.tsx
+++ b/src/components/device/LazyImage.tsx
@@ -12,11 +12,7 @@ type LazyImageProps = {
 const LazyImage = memo(({ device = {} as Device, className }: Readonly<LazyImageProps>) => {
     const fromDefinition = device.definition?.icon;
     const fromZ2MDocs = getZ2MDeviceImage(device);
-    const srcList: string[] = [];
-
-    if (fromDefinition) {
-        srcList.push(fromDefinition);
-    }
+    const srcList: string[] = fromDefinition ? [fromDefinition] : [];
 
     if (fromZ2MDocs) {
         srcList.push(...fromZ2MDocs);

--- a/src/components/device/LazyImage.tsx
+++ b/src/components/device/LazyImage.tsx
@@ -19,10 +19,10 @@ const LazyImage = memo(({ device = {} as Device, className }: Readonly<LazyImage
     }
 
     if (fromZ2MDocs) {
-        srcList.push(fromZ2MDocs);
+        srcList.push(...fromZ2MDocs);
     }
 
-    if (fromZ2MDocs !== genericDevice) {
+    if (!fromZ2MDocs.includes(genericDevice)) {
         srcList.push(genericDevice);
     }
 

--- a/src/components/device/index.tsx
+++ b/src/components/device/index.tsx
@@ -1,22 +1,18 @@
 import type { Device } from "../../types.js";
-import { sanitizeZ2MDeviceName } from "../../utils.js";
 
 const DEVICE_IMAGE_BASE_PATH = "https://www.zigbee2mqtt.io/images/devices/";
 const VENDOR_IMAGE_BASE_PATH = "https://www.zigbee2mqtt.io/images/vendors/";
 
 export const getZ2MDeviceImage = (device: Device): string[] => {
-    const sanitizedName = sanitizeZ2MDeviceName(device.definition?.model);
-    const srcList: string[] = [];
+    const modelFilename = device.definition?.model.replace(/:|\s|\//g, "-");
+    const srcList: string[] = modelFilename ? [`${DEVICE_IMAGE_BASE_PATH}${modelFilename}.png`] : [];
 
-    if (sanitizedName !== "NA") {
-        srcList.push(`${DEVICE_IMAGE_BASE_PATH}${sanitizedName}.png`);
+    if (device.definition && device.definition.source !== "native") {
+        const vendorFilename = device.definition.vendor.replace(/:|\s|\//g, "-");
+
+        srcList.push(`${VENDOR_IMAGE_BASE_PATH}${vendorFilename}.png`);
     }
-    if (device.definition?.source !== "native") {
-        const sanitizedVendorName = sanitizeZ2MDeviceName(device.definition?.vendor);
-        if (sanitizedVendorName !== "NA") {
-            srcList.push(`${VENDOR_IMAGE_BASE_PATH}${sanitizedVendorName}.png`);
-        }
-    }
+
     return srcList;
 };
 

--- a/src/components/device/index.tsx
+++ b/src/components/device/index.tsx
@@ -1,4 +1,3 @@
-import genericDevice from "../../images/generic-zigbee-device.png";
 import type { Device } from "../../types.js";
 import { sanitizeZ2MDeviceName } from "../../utils.js";
 
@@ -7,22 +6,17 @@ const VENDOR_IMAGE_BASE_PATH = "https://www.zigbee2mqtt.io/images/vendors/";
 
 export const getZ2MDeviceImage = (device: Device): string[] => {
     const sanitizedName = sanitizeZ2MDeviceName(device.definition?.model);
-    const sanitizedVendorName = sanitizeZ2MDeviceName(device.definition?.vendor);
-
     const srcList: string[] = [];
 
     if (sanitizedName !== "NA") {
         srcList.push(`${DEVICE_IMAGE_BASE_PATH}${sanitizedName}.png`);
     }
-
-    if (sanitizedVendorName !== "NA") {
-        srcList.push(`${VENDOR_IMAGE_BASE_PATH}${sanitizedVendorName}.png`);
+    if (device.definition?.source !== "native") {
+        const sanitizedVendorName = sanitizeZ2MDeviceName(device.definition?.vendor);
+        if (sanitizedVendorName !== "NA") {
+            srcList.push(`${VENDOR_IMAGE_BASE_PATH}${sanitizedVendorName}.png`);
+        }
     }
-
-    if (sanitizedName === "NA" && sanitizedVendorName === "NA") {
-        srcList.push(genericDevice);
-    }
-
     return srcList;
 };
 

--- a/src/components/device/index.tsx
+++ b/src/components/device/index.tsx
@@ -3,11 +3,27 @@ import type { Device } from "../../types.js";
 import { sanitizeZ2MDeviceName } from "../../utils.js";
 
 const DEVICE_IMAGE_BASE_PATH = "https://www.zigbee2mqtt.io/images/devices/";
+const VENDOR_IMAGE_BASE_PATH = "https://www.zigbee2mqtt.io/images/vendors/";
 
-export const getZ2MDeviceImage = (device: Device): string => {
+export const getZ2MDeviceImage = (device: Device): string[] => {
     const sanitizedName = sanitizeZ2MDeviceName(device.definition?.model);
+    const sanitizedVendorName = sanitizeZ2MDeviceName(device.definition?.vendor);
 
-    return sanitizedName === "NA" ? genericDevice : `${DEVICE_IMAGE_BASE_PATH}${sanitizedName}.png`;
+    const srcList: string[] = [];
+
+    if (sanitizedName !== "NA") {
+        srcList.push(`${DEVICE_IMAGE_BASE_PATH}${sanitizedName}.png`);
+    }
+
+    if (sanitizedVendorName !== "NA") {
+        srcList.push(`${VENDOR_IMAGE_BASE_PATH}${sanitizedVendorName}.png`);
+    }
+
+    if (sanitizedName === "NA" && sanitizedVendorName === "NA") {
+        srcList.push(genericDevice);
+    }
+
+    return srcList;
 };
 
 export const hasOtaCluster = (device: Device): boolean => {

--- a/src/components/network-page/RawNetworkMap.tsx
+++ b/src/components/network-page/RawNetworkMap.tsx
@@ -38,6 +38,27 @@ type RawNetworkMapProps = {
     map: Zigbee2MQTTNetworkMap;
 };
 
+async function testImageUrl(url: string): Promise<boolean> {
+    try {
+        const response = await fetch(url, { method: "HEAD" });
+        return response.ok;
+    } catch {
+        return false;
+    }
+}
+
+async function findFirstValidImageUrl(imageUrls: string[]): Promise<string | undefined> {
+    for (const url of imageUrls) {
+        if (url === genericDevice) {
+            continue;
+        }
+        if (await testImageUrl(url)) {
+            return url;
+        }
+    }
+    return undefined;
+}
+
 const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
     const { t } = useTranslation("network");
     const devices = useAppStore(useShallow((state) => state.devices[sourceIdx]));
@@ -53,11 +74,34 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
     const [showParents, setShowParents] = useState(true);
     const [showChildren, setShowChildren] = useState(true);
     const [showSiblings, setShowSiblings] = useState(true);
+    const [validImageUrls, setValidImageUrls] = useState<Record<string, string>>({});
     const graphRef = useRef<GraphCanvasRef | null>(null);
 
     useEffect(() => {
         store2.set(NETWORK_MAP_CONFIG_KEY, config);
     }, [config]);
+
+    useEffect(() => {
+        if (!config.showIcons) {
+            return;
+        }
+
+        const testUrls = async () => {
+            const results: Record<string, string> = {};
+            for (const device of devices) {
+                if (!device.definition?.icon) {
+                    const imageUrls = getZ2MDeviceImage(device);
+                    const validUrl = await findFirstValidImageUrl(imageUrls);
+                    if (validUrl) {
+                        results[device.ieee_address] = validUrl;
+                    }
+                }
+            }
+            setValidImageUrls(results);
+        };
+
+        void testUrls();
+    }, [config.showIcons, devices]);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: specific trigger
     useEffect(() => {
@@ -136,11 +180,7 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
             let icon: string | undefined;
 
             if (config.showIcons && device) {
-                icon = device.definition?.icon ?? getZ2MDeviceImage(device)[0];
-
-                if (icon === genericDevice) {
-                    icon = undefined;
-                }
+                icon = device.definition?.icon ?? validImageUrls[device.ieee_address];
             }
 
             computedNodes.push({
@@ -233,7 +273,7 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
         }
 
         return [computedNodes, computedEdges];
-    }, [map, showParents, showChildren, showSiblings, t, devices, config.showIcons]);
+    }, [map, showParents, showChildren, showSiblings, t, devices, config.showIcons, validImageUrls]);
 
     const { selections, actives, onNodeClick, onCanvasClick } = useSelection({
         ref: graphRef,

--- a/src/components/network-page/RawNetworkMap.tsx
+++ b/src/components/network-page/RawNetworkMap.tsx
@@ -136,7 +136,7 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
             let icon: string | undefined;
 
             if (config.showIcons && device) {
-                icon = device.definition?.icon ?? getZ2MDeviceImage(device);
+                icon = device.definition?.icon ?? getZ2MDeviceImage(device)[0];
 
                 if (icon === genericDevice) {
                     icon = undefined;

--- a/src/components/network-page/RawNetworkMap.tsx
+++ b/src/components/network-page/RawNetworkMap.tsx
@@ -91,9 +91,14 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
             for (const device of devices) {
                 if (!device.definition?.icon) {
                     const imageUrls = getZ2MDeviceImage(device);
-                    const validUrl = await findFirstValidImageUrl(imageUrls);
-                    if (validUrl) {
-                        results[device.ieee_address] = validUrl;
+                    if (device.definition?.source !== "native") {
+                        const validUrl = await findFirstValidImageUrl(imageUrls);
+                        if (validUrl) {
+                            results[device.ieee_address] = validUrl;
+                        }
+                    } else if (imageUrls[0] !== genericDevice) {
+                        // for native supported devices the first entry is the model image
+                        results[device.ieee_address] = imageUrls[0];
                     }
                 }
             }

--- a/src/components/network-page/RawNetworkMap.tsx
+++ b/src/components/network-page/RawNetworkMap.tsx
@@ -15,7 +15,7 @@ import {
 import store2 from "store2";
 import type { Zigbee2MQTTNetworkMap } from "zigbee2mqtt";
 import { useShallow } from "zustand/react/shallow";
-import genericDevice from "../../images/generic-zigbee-device.png";
+// import genericDevice from "../../images/generic-zigbee-device.png";
 import { NETWORK_MAP_CONFIG_KEY } from "../../localStoreConsts.js";
 import { useAppStore } from "../../store.js";
 import fontUrl from "./../../styles/NotoSans-Regular.ttf";
@@ -47,14 +47,18 @@ async function testImageUrl(url: string): Promise<boolean> {
     }
 }
 
-async function findFirstValidImageUrl(imageUrls: string[]): Promise<string | undefined> {
+async function findFirstValidImageUrl(imageUrls: string[], validUrls: Set<string>, invalidUrls: Set<string>): Promise<string | undefined> {
     for (const url of imageUrls) {
-        if (url === genericDevice) {
+        if (validUrls.has(url)) {
+            return url;
+        }
+        if (invalidUrls.has(url)) {
             continue;
         }
         if (await testImageUrl(url)) {
             return url;
         }
+        invalidUrls.add(url);
     }
     return undefined;
 }
@@ -74,35 +78,44 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
     const [showParents, setShowParents] = useState(true);
     const [showChildren, setShowChildren] = useState(true);
     const [showSiblings, setShowSiblings] = useState(true);
-    const [validImageUrls, setValidImageUrls] = useState<Record<string, string>>({});
+    const [validImageUrls, setValidImageUrls] = useState<Map<string, string>>(new Map());
+    const [invalidImageUrls, setInvalidImageUrls] = useState<Set<string>>(new Set());
     const graphRef = useRef<GraphCanvasRef | null>(null);
 
     useEffect(() => {
         store2.set(NETWORK_MAP_CONFIG_KEY, config);
     }, [config]);
 
+    // biome-ignore lint/correctness/useExhaustiveDependencies(invalidImageUrls): copy state at effect time, avoid re-runs from state changes
+    // biome-ignore lint/correctness/useExhaustiveDependencies(validImageUrls): copy state at effect time, avoid re-runs from state changes
     useEffect(() => {
         if (!config.showIcons) {
             return;
         }
 
         const testUrls = async () => {
-            const results: Record<string, string> = {};
+            const results = new Map(validImageUrls);
+            const invalidUrls = new Set(invalidImageUrls);
             for (const device of devices) {
                 if (!device.definition?.icon) {
                     const imageUrls = getZ2MDeviceImage(device);
                     if (device.definition?.source !== "native") {
-                        const validUrl = await findFirstValidImageUrl(imageUrls);
+                        const validUrl = await findFirstValidImageUrl(imageUrls, new Set(results.values()), invalidUrls);
                         if (validUrl) {
-                            results[device.ieee_address] = validUrl;
+                            results.set(device.ieee_address, validUrl);
+                        } else {
+                            results.delete(device.ieee_address);
                         }
-                    } else if (imageUrls[0] !== genericDevice) {
+                    } else if (imageUrls.length > 0) {
                         // for native supported devices the first entry is the model image
-                        results[device.ieee_address] = imageUrls[0];
+                        results.set(device.ieee_address, imageUrls[0]);
+                    } else {
+                        results.delete(device.ieee_address);
                     }
                 }
             }
             setValidImageUrls(results);
+            setInvalidImageUrls(invalidUrls);
         };
 
         void testUrls();
@@ -185,7 +198,7 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
             let icon: string | undefined;
 
             if (config.showIcons && device) {
-                icon = device.definition?.icon ?? validImageUrls[device.ieee_address];
+                icon = device.definition?.icon ?? validImageUrls.get(device.ieee_address);
             }
 
             computedNodes.push({

--- a/src/components/network-page/RawNetworkMap.tsx
+++ b/src/components/network-page/RawNetworkMap.tsx
@@ -15,7 +15,6 @@ import {
 import store2 from "store2";
 import type { Zigbee2MQTTNetworkMap } from "zigbee2mqtt";
 import { useShallow } from "zustand/react/shallow";
-// import genericDevice from "../../images/generic-zigbee-device.png";
 import { NETWORK_MAP_CONFIG_KEY } from "../../localStoreConsts.js";
 import { useAppStore } from "../../store.js";
 import fontUrl from "./../../styles/NotoSans-Regular.ttf";
@@ -38,36 +37,6 @@ type RawNetworkMapProps = {
     map: Zigbee2MQTTNetworkMap;
 };
 
-async function testImageUrl(url: string): Promise<boolean> {
-    try {
-        const response = await fetch(url, { method: "HEAD" });
-
-        return response.ok;
-    } catch {
-        return false;
-    }
-}
-
-async function findFirstValidImageUrl(imageUrls: string[], validUrls: Set<string>, invalidUrls: Set<string>): Promise<string | undefined> {
-    for (const url of imageUrls) {
-        if (validUrls.has(url)) {
-            return url;
-        }
-
-        if (invalidUrls.has(url)) {
-            continue;
-        }
-
-        if (await testImageUrl(url)) {
-            return url;
-        }
-
-        invalidUrls.add(url);
-    }
-
-    return undefined;
-}
-
 const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
     const { t } = useTranslation("network");
     const devices = useAppStore(useShallow((state) => state.devices[sourceIdx]));
@@ -83,52 +52,11 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
     const [showParents, setShowParents] = useState(true);
     const [showChildren, setShowChildren] = useState(true);
     const [showSiblings, setShowSiblings] = useState(true);
-    const [validImageUrls, setValidImageUrls] = useState<Map<string, string>>(new Map());
-    const [invalidImageUrls, setInvalidImageUrls] = useState<Set<string>>(new Set());
     const graphRef = useRef<GraphCanvasRef | null>(null);
 
     useEffect(() => {
         store2.set(NETWORK_MAP_CONFIG_KEY, config);
     }, [config]);
-
-    // biome-ignore lint/correctness/useExhaustiveDependencies(invalidImageUrls): copy state at effect time, avoid re-runs from state changes
-    // biome-ignore lint/correctness/useExhaustiveDependencies(validImageUrls): copy state at effect time, avoid re-runs from state changes
-    useEffect(() => {
-        if (!config.showIcons) {
-            return;
-        }
-
-        const testUrls = async () => {
-            const results = new Map(validImageUrls);
-            const invalidUrls = new Set(invalidImageUrls);
-
-            for (const device of devices) {
-                if (!device.definition?.icon) {
-                    const imageUrls = getZ2MDeviceImage(device);
-
-                    if (device.definition?.source !== "native") {
-                        const validUrl = await findFirstValidImageUrl(imageUrls, new Set(results.values()), invalidUrls);
-
-                        if (validUrl) {
-                            results.set(device.ieee_address, validUrl);
-                        } else {
-                            results.delete(device.ieee_address);
-                        }
-                    } else if (imageUrls.length > 0) {
-                        // for native supported devices the first entry is the model image
-                        results.set(device.ieee_address, imageUrls[0]);
-                    } else {
-                        results.delete(device.ieee_address);
-                    }
-                }
-            }
-
-            setValidImageUrls(results);
-            setInvalidImageUrls(invalidUrls);
-        };
-
-        void testUrls();
-    }, [config.showIcons, devices]);
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: specific trigger
     useEffect(() => {
@@ -204,12 +132,6 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
                 }
             }
 
-            let icon: string | undefined;
-
-            if (config.showIcons && device) {
-                icon = device.definition?.icon ?? validImageUrls.get(device.ieee_address);
-            }
-
             computedNodes.push({
                 id: node.ieeeAddr,
                 data: {
@@ -219,7 +141,7 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
                 label: node.friendlyName,
                 labelVisible: true,
                 fill: NODE_TYPE_FILL_COLORS[node.type as keyof typeof NODE_TYPE_FILL_COLORS],
-                icon,
+                icon: config.showIcons && device ? (device.definition?.icon ?? getZ2MDeviceImage(device)[0]) : undefined,
             });
         }
 
@@ -300,7 +222,7 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
         }
 
         return [computedNodes, computedEdges];
-    }, [map, showParents, showChildren, showSiblings, t, devices, config.showIcons, validImageUrls]);
+    }, [map, showParents, showChildren, showSiblings, t, devices, config.showIcons]);
 
     const { selections, actives, onNodeClick, onCanvasClick } = useSelection({
         ref: graphRef,

--- a/src/components/network-page/RawNetworkMap.tsx
+++ b/src/components/network-page/RawNetworkMap.tsx
@@ -141,7 +141,10 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
                 label: node.friendlyName,
                 labelVisible: true,
                 fill: NODE_TYPE_FILL_COLORS[node.type as keyof typeof NODE_TYPE_FILL_COLORS],
-                icon: config.showIcons && device ? (device.definition?.icon ?? getZ2MDeviceImage(device)[0]) : undefined,
+                icon:
+                    config.showIcons && device?.definition
+                        ? device.definition.icon || (device.supported ? getZ2MDeviceImage(device)[0] : undefined)
+                        : undefined,
             });
         }
 

--- a/src/components/network-page/RawNetworkMap.tsx
+++ b/src/components/network-page/RawNetworkMap.tsx
@@ -41,6 +41,7 @@ type RawNetworkMapProps = {
 async function testImageUrl(url: string): Promise<boolean> {
     try {
         const response = await fetch(url, { method: "HEAD" });
+
         return response.ok;
     } catch {
         return false;
@@ -52,14 +53,18 @@ async function findFirstValidImageUrl(imageUrls: string[], validUrls: Set<string
         if (validUrls.has(url)) {
             return url;
         }
+
         if (invalidUrls.has(url)) {
             continue;
         }
+
         if (await testImageUrl(url)) {
             return url;
         }
+
         invalidUrls.add(url);
     }
+
     return undefined;
 }
 
@@ -96,11 +101,14 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
         const testUrls = async () => {
             const results = new Map(validImageUrls);
             const invalidUrls = new Set(invalidImageUrls);
+
             for (const device of devices) {
                 if (!device.definition?.icon) {
                     const imageUrls = getZ2MDeviceImage(device);
+
                     if (device.definition?.source !== "native") {
                         const validUrl = await findFirstValidImageUrl(imageUrls, new Set(results.values()), invalidUrls);
+
                         if (validUrl) {
                             results.set(device.ieee_address, validUrl);
                         } else {
@@ -114,6 +122,7 @@ const RawNetworkMap = memo(({ sourceIdx, map }: RawNetworkMapProps) => {
                     }
                 }
             }
+
             setValidImageUrls(results);
             setInvalidImageUrls(invalidUrls);
         };

--- a/src/components/ota-page/OtaFileVersion.tsx
+++ b/src/components/ota-page/OtaFileVersion.tsx
@@ -1,8 +1,8 @@
+import { faCheckCircle, faSquareArrowUpRight } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { formatOtaFileVersion } from "./index.js";
-import { faCheckCircle, faSquareArrowUpRight } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 type OtaFileVersionProps = {
     version?: number | null;

--- a/src/components/settings-page/ImageLocaliser.tsx
+++ b/src/components/settings-page/ImageLocaliser.tsx
@@ -79,7 +79,9 @@ export function ImageLocaliser({ sourceIdx, devices }: Props): JSX.Element {
         if (currentState === "start") {
             for (const device of devices) {
                 if (device.type !== "Coordinator") {
-                    localiseImage(device).catch((err) => { console.log(err); });
+                    localiseImage(device).catch((err) => {
+                        console.log(err);
+                    });
                 }
             }
 

--- a/src/components/settings-page/ImageLocaliser.tsx
+++ b/src/components/settings-page/ImageLocaliser.tsx
@@ -60,9 +60,13 @@ export function ImageLocaliser({ sourceIdx, devices }: Props): JSX.Element {
                 }
             }
 
-            await sendMessage(sourceIdx, "bridge/request/device/options", { id: device.ieee_address, options: { icon: imageContent } });
-            setLocalisationStatus((prev) => ({ ...prev, [device.ieee_address]: "done" }));
-
+            if (!imageContent) {
+                console.error("Error localising image");
+                setLocalisationStatus((prev) => ({ ...prev, [device.ieee_address]: "error" }));
+            } else {
+                await sendMessage(sourceIdx, "bridge/request/device/options", { id: device.ieee_address, options: { icon: imageContent } });
+                setLocalisationStatus((prev) => ({ ...prev, [device.ieee_address]: "done" }));
+            }
             return true;
         },
         [sourceIdx],
@@ -72,10 +76,7 @@ export function ImageLocaliser({ sourceIdx, devices }: Props): JSX.Element {
         if (currentState === "start") {
             for (const device of devices) {
                 if (device.type !== "Coordinator") {
-                    localiseImage(device).catch((err) => {
-                        console.error("Error localising image", err);
-                        setLocalisationStatus((prev) => ({ ...prev, [device.ieee_address]: "error" }));
-                    });
+                    void localiseImage(device);
                 }
             }
 

--- a/src/components/settings-page/ImageLocaliser.tsx
+++ b/src/components/settings-page/ImageLocaliser.tsx
@@ -48,8 +48,17 @@ export function ImageLocaliser({ sourceIdx, devices }: Props): JSX.Element {
                 return { ...prev, [device.ieee_address]: "init" };
             });
 
-            const imageUrl = getZ2MDeviceImage(device)[0];
-            const imageContent = await downloadImage(imageUrl);
+            const imageUrls = getZ2MDeviceImage(device);
+
+            let imageContent: string | null = null;
+            for (const url of imageUrls) {
+                try {
+                    imageContent = await downloadImage(url);
+                    break;
+                } catch {
+                    // ignore silently
+                }
+            }
 
             await sendMessage(sourceIdx, "bridge/request/device/options", { id: device.ieee_address, options: { icon: imageContent } });
             setLocalisationStatus((prev) => ({ ...prev, [device.ieee_address]: "done" }));

--- a/src/components/settings-page/ImageLocaliser.tsx
+++ b/src/components/settings-page/ImageLocaliser.tsx
@@ -48,7 +48,7 @@ export function ImageLocaliser({ sourceIdx, devices }: Props): JSX.Element {
                 return { ...prev, [device.ieee_address]: "init" };
             });
 
-            const imageUrl = getZ2MDeviceImage(device);
+            const imageUrl = getZ2MDeviceImage(device)[0];
             const imageContent = await downloadImage(imageUrl);
 
             await sendMessage(sourceIdx, "bridge/request/device/options", { id: device.ieee_address, options: { icon: imageContent } });

--- a/src/components/settings-page/ImageLocaliser.tsx
+++ b/src/components/settings-page/ImageLocaliser.tsx
@@ -7,13 +7,13 @@ import Button from "../Button.js";
 import { getZ2MDeviceImage } from "../device/index.js";
 
 type LocaliserState = "none" | "start" | "inprogress" | "done";
+// Maps to i18n keys in `common` ns
+type LocaliserStatus = "init" | "error" | "done";
 
 type Props = {
     sourceIdx: number;
     devices: AppState["devices"][number];
 };
-
-type LStatus = "init" | "error" | "done";
 
 async function blobToBase64(blob: Blob): Promise<string> {
     return await new Promise((resolve, reject) => {
@@ -25,21 +25,24 @@ async function blobToBase64(blob: Blob): Promise<string> {
     });
 }
 
-async function downloadImage(imageSrc: string): Promise<string> {
-    const image = await fetch(imageSrc);
+async function downloadImage(imageSrc: string): Promise<string | undefined> {
+    try {
+        const rsp = await fetch(imageSrc);
 
-    if (image.ok) {
-        const blob = await image.blob();
+        if (rsp.ok) {
+            const blob = await rsp.blob();
+            const base64 = await blobToBase64(blob);
 
-        return await blobToBase64(blob);
+            return base64;
+        }
+    } catch {
+        // ignore
     }
-
-    return Promise.reject(image.status);
 }
 
 export function ImageLocaliser({ sourceIdx, devices }: Props): JSX.Element {
     const [currentState, setCurrentState] = useState<LocaliserState>("none");
-    const [localisationStatus, setLocalisationStatus] = useState<Record<string, LStatus>>({});
+    const [localisationStatus, setLocalisationStatus] = useState<Record<string, LocaliserStatus>>({});
     const { t } = useTranslation(["settings", "common", "zigbee"]);
 
     const localiseImage = useCallback(
@@ -49,14 +52,13 @@ export function ImageLocaliser({ sourceIdx, devices }: Props): JSX.Element {
             });
 
             const imageUrls = getZ2MDeviceImage(device);
+            let imageContent: string | undefined;
 
-            let imageContent: string | null = null;
             for (const url of imageUrls) {
-                try {
-                    imageContent = await downloadImage(url);
+                imageContent = await downloadImage(url);
+
+                if (imageContent) {
                     break;
-                } catch {
-                    // ignore silently
                 }
             }
 
@@ -67,6 +69,7 @@ export function ImageLocaliser({ sourceIdx, devices }: Props): JSX.Element {
                 await sendMessage(sourceIdx, "bridge/request/device/options", { id: device.ieee_address, options: { icon: imageContent } });
                 setLocalisationStatus((prev) => ({ ...prev, [device.ieee_address]: "done" }));
             }
+
             return true;
         },
         [sourceIdx],
@@ -76,7 +79,7 @@ export function ImageLocaliser({ sourceIdx, devices }: Props): JSX.Element {
         if (currentState === "start") {
             for (const device of devices) {
                 if (device.type !== "Coordinator") {
-                    void localiseImage(device);
+                    localiseImage(device).catch((err) => { console.log(err); });
                 }
             }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,8 +83,6 @@ export const toHex = (input: number, padding = 4): string => {
     return `0x${(padStr + input.toString(16)).slice(-1 * padding).toUpperCase()}`;
 };
 
-export const sanitizeZ2MDeviceName = (deviceName?: string): string | "NA" => (deviceName ? deviceName.replace(/:|\s|\//g, "-") : "NA");
-
 // #endregion
 
 // #region Device/Group


### PR DESCRIPTION
This PR adds a vendor image lookup from https://www.zigbee2mqtt.io/images/vendors/ as discussed in #607. I guess there are many ways to do this, please let me know if you prefer another approach. Also the images could stay in  https://www.zigbee2mqtt.io/images/devices.

<img width="513" height="316" alt="grafik" src="https://github.com/user-attachments/assets/226ae1f9-53b9-43a4-b963-fc39b93f0617" />
