### PR TITLE
fix: fix rounded corners on some buttons

### DIFF
--- a/src/components/device-page/tabs/Bind.tsx
+++ b/src/components/device-page/tabs/Bind.tsx
@@ -180,7 +180,7 @@ export default function Bind({ sourceIdx, device }: BindProps): JSX.Element {
         <div className="flex flex-col w-full gap-3">
             <div className="flex flex-row flex-wrap gap-3">
                 <ConfirmButton
-                    className="btn btn-outline btn-error join-item"
+                    className="btn btn-outline btn-error"
                     item={[sourceIdx, device.ieee_address, [device.ieee_address]]}
                     onClick={onClear}
                     title={t(($) => $.clear_self_as_source)}
@@ -191,7 +191,7 @@ export default function Bind({ sourceIdx, device }: BindProps): JSX.Element {
                     {t(($) => $.clear_self_as_source)}
                 </ConfirmButton>
                 <ConfirmButton
-                    className="btn btn-outline btn-error join-item"
+                    className="btn btn-outline btn-error"
                     item={[sourceIdx, device.ieee_address, ["0xffffffffffffffff"]]}
                     onClick={onClear}
                     title={t(($) => $.clear_all)}

--- a/src/components/editors/EnumEditor.tsx
+++ b/src/components/editors/EnumEditor.tsx
@@ -52,7 +52,7 @@ const EnumEditor = memo((props: EnumProps) => {
             })}
         </select>
     ) : (
-        <div className="flex flex-row flex-wrap gap-1">
+        <div className="flex flex-row flex-wrap gap-1 join">
             {values.map((v) => {
                 const primitive = isPrimitive(v);
                 const current = primitive ? v === value : v.value === (primitiveValue ? value : value?.value);

--- a/src/components/editors/EnumEditor.tsx
+++ b/src/components/editors/EnumEditor.tsx
@@ -52,7 +52,7 @@ const EnumEditor = memo((props: EnumProps) => {
             })}
         </select>
     ) : (
-        <div className="flex flex-row flex-wrap gap-1 join">
+        <div className="flex flex-row flex-wrap gap-1">
             {values.map((v) => {
                 const primitive = isPrimitive(v);
                 const current = primitive ? v === value : v.value === (primitiveValue ? value : value?.value);
@@ -60,7 +60,7 @@ const EnumEditor = memo((props: EnumProps) => {
                 return (
                     <Button<ValueWithLabelOrPrimitive>
                         key={primitive ? v : v.name}
-                        className={`btn btn-outline btn-primary btn-sm join-item${current ? " btn-active" : ""}`}
+                        className={`btn btn-outline btn-primary btn-sm${current ? " btn-active" : ""}`}
                         onClick={onChange}
                         item={primitive ? v : v.value}
                         title={primitive ? `${v}` : v.description}

--- a/src/components/ota-page/OtaControlGroup.tsx
+++ b/src/components/ota-page/OtaControlGroup.tsx
@@ -179,7 +179,7 @@ const OtaControlGroup = memo(
             <>
                 {isScheduled ? (
                     <Button<{ sourceIdx: number; ieee: string }>
-                        className="btn btn-sm btn-square btn-outline btn-error join-item"
+                        className="btn btn-sm btn-square btn-outline btn-error"
                         onClick={onUnscheduleClick}
                         item={{ sourceIdx, ieee: device.ieee_address }}
                         title={t(($) => $.unschedule)}
@@ -190,7 +190,7 @@ const OtaControlGroup = memo(
                     <button
                         ref={refs.setReference}
                         type="button"
-                        className="btn btn-sm btn-square btn-outline btn-primary join-item tooltip tooltip-top"
+                        className="btn btn-sm btn-square btn-outline btn-primary tooltip tooltip-top"
                         {...getReferenceProps()}
                         data-tip="OTA"
                         disabled={disableOta}
@@ -336,9 +336,9 @@ const OtaControlGroup = memo(
                                         )}
                                     </div>
                                 </div>
-                                <div className="card-actions justify-end py-2">
+                                <div className="card-actions justify-end py-2 join">
                                     <Button
-                                        className="btn btn-square btn-outline btn-primary tooltip-left"
+                                        className="btn btn-square btn-outline btn-primary tooltip-left join-item"
                                         onClick={handleAction}
                                         item="check"
                                         title={t(($) => $.check)}
@@ -347,7 +347,7 @@ const OtaControlGroup = memo(
                                         <FontAwesomeIcon icon={faCloudArrowDown} />
                                     </Button>
                                     <Button
-                                        className="btn btn-square btn-outline btn-error tooltip-left"
+                                        className="btn btn-square btn-outline btn-error tooltip-left join-item"
                                         onClick={handleAction}
                                         item="update"
                                         title={t(($) => $.update)}
@@ -356,7 +356,7 @@ const OtaControlGroup = memo(
                                         <FontAwesomeIcon icon={faUpload} />
                                     </Button>
                                     <Button
-                                        className="btn btn-square btn-outline btn-info tooltip-left"
+                                        className="btn btn-square btn-outline btn-info tooltip-left join-item"
                                         onClick={handleAction}
                                         item="schedule"
                                         title={t(($) => $.schedule)}

--- a/src/components/ota-page/OtaControlGroup.tsx
+++ b/src/components/ota-page/OtaControlGroup.tsx
@@ -336,9 +336,9 @@ const OtaControlGroup = memo(
                                         )}
                                     </div>
                                 </div>
-                                <div className="card-actions justify-end py-2 join">
+                                <div className="card-actions justify-end py-2">
                                     <Button
-                                        className="btn btn-square btn-outline btn-primary tooltip-left join-item"
+                                        className="btn btn-square btn-outline btn-primary tooltip-left"
                                         onClick={handleAction}
                                         item="check"
                                         title={t(($) => $.check)}
@@ -347,7 +347,7 @@ const OtaControlGroup = memo(
                                         <FontAwesomeIcon icon={faCloudArrowDown} />
                                     </Button>
                                     <Button
-                                        className="btn btn-square btn-outline btn-error tooltip-left join-item"
+                                        className="btn btn-square btn-outline btn-error tooltip-left"
                                         onClick={handleAction}
                                         item="update"
                                         title={t(($) => $.update)}
@@ -356,7 +356,7 @@ const OtaControlGroup = memo(
                                         <FontAwesomeIcon icon={faUpload} />
                                     </Button>
                                     <Button
-                                        className="btn btn-square btn-outline btn-info tooltip-left join-item"
+                                        className="btn btn-square btn-outline btn-info tooltip-left"
                                         onClick={handleAction}
                                         item="schedule"
                                         title={t(($) => $.schedule)}

--- a/src/components/ota-page/OtaUpdateButton.tsx
+++ b/src/components/ota-page/OtaUpdateButton.tsx
@@ -181,7 +181,7 @@ const OtaUpdateButton = memo(({ sourceIdx, device, state, otaSettings, onUpdateC
                                     <OtaDataSettings settings={updateSettings} setSettings={setUpdateSettings} defaultSettings={otaSettings} />
                                 ) : null}
                             </div>
-                            <div className="card-actions justify-end py-2">
+                            <div className="card-actions justify-end py-2 join">
                                 <Button
                                     className="btn btn-square btn-outline btn-error join-item tooltip-left"
                                     onClick={handleAction}

--- a/src/components/ota-page/OtaUpdateButton.tsx
+++ b/src/components/ota-page/OtaUpdateButton.tsx
@@ -181,9 +181,9 @@ const OtaUpdateButton = memo(({ sourceIdx, device, state, otaSettings, onUpdateC
                                     <OtaDataSettings settings={updateSettings} setSettings={setUpdateSettings} defaultSettings={otaSettings} />
                                 ) : null}
                             </div>
-                            <div className="card-actions justify-end py-2 join">
+                            <div className="card-actions justify-end py-2">
                                 <Button
-                                    className="btn btn-square btn-outline btn-error join-item tooltip-left"
+                                    className="btn btn-square btn-outline btn-error tooltip-left"
                                     onClick={handleAction}
                                     item="update"
                                     title={t(($) => $.update)}
@@ -191,7 +191,7 @@ const OtaUpdateButton = memo(({ sourceIdx, device, state, otaSettings, onUpdateC
                                     <FontAwesomeIcon icon={faUpload} />
                                 </Button>
                                 <Button
-                                    className="btn btn-square btn-outline btn-info join-item tooltip-left"
+                                    className="btn btn-square btn-outline btn-info tooltip-left"
                                     onClick={handleAction}
                                     item="schedule"
                                     title={t(($) => $.schedule)}


### PR DESCRIPTION
https://daisyui.com/components/join/

> Join applies border radius to the first and last item.

Some buttons with `join-item` class were inside containers without the `join` class.
This broke their corner radius after the v5.6.x daisyUI update.

I searched the repo by `join-item` and fixed them like this:

<img width="40%" src="https://github.com/user-attachments/assets/5e3124b9-6c1e-4fdc-93ed-568bbd4becec" />
<img width="40%" src="https://github.com/user-attachments/assets/0cb6be17-c9c0-49c7-baac-37c618888c9f" />

<img width="40%" src="https://github.com/user-attachments/assets/cf058fb3-ed0f-4146-b137-b926149d3f29" />
<img width="40%" src="https://github.com/user-attachments/assets/4a394dd2-936d-4f38-87a3-bf4891036638" />

<img width="40%"  src="https://github.com/user-attachments/assets/ba29aaf5-5575-4a90-b9eb-bc739c1a1f46" />
<img width="40%"  src="https://github.com/user-attachments/assets/7efb349e-6ecb-4eb3-a950-7a14409e377e" />

<img width="40%" src="https://github.com/user-attachments/assets/ea721982-2acd-471f-bf67-5a4f3d037445" />
<img width="40%" src="https://github.com/user-attachments/assets/bc6fb346-1a04-4ed2-ad48-ef8f241f6bc7" />

<img width="40%" src="https://github.com/user-attachments/assets/fd56f874-8256-4105-95da-334a45b7cddc" />
<img width="40%" src="https://github.com/user-attachments/assets/d6e609ab-36b2-46b4-87d1-910d858ee330" />
<p/>

Hope I got them all 😁 