### PR TITLE
feat: Add "Zigbee manufacturer" tooltip

### DIFF
--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -334,7 +334,12 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                     <div className="font-semibold text-base-content/70">{t(($) => $.zigbee_model)}</div>
                     <div className="min-w-0">
                         <p className="font-semibold break-all">{device.model_id}</p>
-                        <p className="text-base-content/50">{device.manufacturer}</p>
+                        <p className="text-base-content/50">
+                            <span className="tooltip tooltip-bottom">
+                                <span className="tooltip-content">{t(($) => $.zigbee_manufacturer)}</span>
+                                {device.manufacturer}
+                            </span>
+                        </p>
                     </div>
                     <div className="font-semibold text-base-content/70">{t(($) => $.definition, { ns: "common" })} (Zigbee2MQTT)</div>
                     <div className="min-w-0">

--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -335,8 +335,7 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
                     <div className="min-w-0">
                         <p className="font-semibold break-all">{device.model_id}</p>
                         <p className="text-base-content/50">
-                            <span className="tooltip tooltip-bottom">
-                                <span className="tooltip-content">{t(($) => $.zigbee_manufacturer)}</span>
+                            <span className="tooltip tooltip-bottom" data-tip={t(($) => $.zigbee_manufacturer)}>
                                 {device.manufacturer}
                             </span>
                         </p>


### PR DESCRIPTION
Saw `$.zigbee_manufacturer` was unused. I added it as a tooltip, similar to OUI

<img width="520" height="179" alt="image" src="https://github.com/user-attachments/assets/b1597279-182d-4c24-aa53-5122318820fb" />
