### PR TITLE
fix: highlight buttons with string presets

### DIFF
--- a/src/components/editors/RangeEditor.tsx
+++ b/src/components/editors/RangeEditor.tsx
@@ -13,16 +13,16 @@ import {
 import EnumEditor, { type ValueWithLabelOrPrimitive } from "./EnumEditor.js";
 
 type RangeProps = Omit<InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> & {
-    value: number | "";
+    value: number | string;
     unit?: string;
-    onChange(value: number | null): Promise<void>;
+    onChange(value: number | string | null): Promise<void>;
     steps?: ValueWithLabelOrPrimitive[];
     minimal?: boolean;
 };
 
 const RangeEditor = memo((props: RangeProps) => {
     const { onChange, value, min, max, unit, steps, minimal, ...rest } = props;
-    const [currentValue, setCurrentValue] = useState<number | "">(value);
+    const [currentValue, setCurrentValue] = useState<number | string>(value);
     const showRange = min != null && max != null;
 
     useEffect(() => {

--- a/src/components/features/Numeric.tsx
+++ b/src/components/features/Numeric.tsx
@@ -25,7 +25,7 @@ const Numeric = memo((props: NumericProps) => {
                 onChange={async (value) => {
                     await onChange(property ? { [property]: value } : value);
                 }}
-                value={typeof deviceValue === "number" ? deviceValue : ""}
+                value={typeof deviceValue === "number" || typeof deviceValue === "string" ? deviceValue : ""}
                 min={valueMin}
                 max={valueMax}
                 step={valueStep}


### PR DESCRIPTION
Buttons with string presets are not highlighted correctly
- preset "previous" = 65535 is ok
- preset "previous" = "previous" is not ok

I fixed the type here and it works now.
It's a bit weird to mix numbers and strings in the same feature 🙂

Before:
<img width="1342" height="586" alt="image" src="https://github.com/user-attachments/assets/cce550ed-9410-44d8-ba72-ec64ca02ac72" />

After:
<img width="1342" height="586" alt="image" src="https://github.com/user-attachments/assets/07c53fd6-eab6-4471-90bd-5ebe504bd46c" />