### PR TITLE
fix: prevent fractional groups IDs

### DIFF
--- a/src/pages/GroupsPage.tsx
+++ b/src/pages/GroupsPage.tsx
@@ -80,7 +80,7 @@ export default function GroupsPage() {
         }
 
         const id = Number(newGroupId);
-        if (!Number.isFinite(id) || id < 0x0001 || id > 0xfff7) {
+        if (!Number.isInteger(id) || id < 0x0001 || id > 0xfff7) {
             return false;
         }
 


### PR DESCRIPTION
Already added the ZH check 
- https://github.com/Koenkk/zigbee-herdsman/pull/1863

Maybe also disable the button here..

<img width="534" height="206" alt="image" src="https://github.com/user-attachments/assets/eccde637-f2a2-4f65-867d-bc89adaa587b" />

<img width="534" height="206" alt="image" src="https://github.com/user-attachments/assets/e37af56c-bf40-4a4c-aa9a-8c71300ebd25" />
