### PR TITLE
feat: Remove 'analog_in_' and 'analog_out_' prefixes

### DIFF
--- a/src/components/features/index.tsx
+++ b/src/components/features/index.tsx
@@ -672,6 +672,8 @@ export const getLinkQualityIcon = (linkQuality: number | undefined): [IconDefini
 export const getFeatureIcon = (name: string, value: unknown, unit?: unknown): [IconDefinition, string] => {
     let icon: IconDefinition | undefined;
     let className = "";
+    // Remove analog_in_ and analog_out_ prefix
+    name = name.replace(/^(?:analog_in_|analog_out_)/, "");
 
     switch (name) {
         case "linkquality": {

--- a/src/components/features/index.tsx
+++ b/src/components/features/index.tsx
@@ -672,7 +672,6 @@ export const getLinkQualityIcon = (linkQuality: number | undefined): [IconDefini
 export const getFeatureIcon = (name: string, value: unknown, unit?: unknown): [IconDefinition, string] => {
     let icon: IconDefinition | undefined;
     let className = "";
-    // Remove analog_in_ and analog_out_ prefix
     name = name.replace("analog_in_", "").replace("analog_out_", "");
 
     switch (name) {

--- a/src/components/features/index.tsx
+++ b/src/components/features/index.tsx
@@ -673,7 +673,7 @@ export const getFeatureIcon = (name: string, value: unknown, unit?: unknown): [I
     let icon: IconDefinition | undefined;
     let className = "";
     // Remove analog_in_ and analog_out_ prefix
-    name = name.replace(/^(?:analog_in_|analog_out_)/, "");
+    name = name.replace("analog_in_", "").replace("analog_out_", "");
 
     switch (name) {
         case "linkquality": {


### PR DESCRIPTION
Remove 'analog_in_' and 'analog_out_' prefixes from feature names.
Align with https://github.com/Koenkk/zigbee2mqtt/pull/32654