### PR TITLE
feat: add device expose localization support

### DIFF
--- a/src/components/dashboard-page/DashboardFeatureWrapper.tsx
+++ b/src/components/dashboard-page/DashboardFeatureWrapper.tsx
@@ -4,19 +4,22 @@ import type { PropsWithChildren } from "react";
 import { useTranslation } from "react-i18next";
 import type { FeatureWrapperProps } from "../features/FeatureWrapper.js";
 import { getFeatureIcon } from "../features/index.js";
+import { getExposeLabel } from "../../utils/exposeTranslations.js";
 
 export default function DashboardFeatureWrapper({ children, feature, deviceValue, endpointSpecific }: PropsWithChildren<FeatureWrapperProps>) {
     // @ts-expect-error `undefined` is fine
     const unit = feature.unit as string | undefined;
     const [fi, fiClassName] = getFeatureIcon(feature.name, deviceValue, unit);
-    const { t } = useTranslation("zigbee");
+    const { t, i18n } = useTranslation("zigbee");
+    const locale = i18n.language?.split("-")[0] ?? "en";
     const featureName = feature.name === "state" ? feature.property : feature.name;
+    const label = getExposeLabel(feature, locale) || startCase(featureName);
 
     return (
         <div className="flex flex-row items-center gap-1 mb-2">
             <FontAwesomeIcon icon={fi} className={fiClassName} />
             <div className="grow-1" title={featureName}>
-                {startCase(featureName)}
+                {label}
                 {!endpointSpecific && <span title={t(($) => $.endpoint)}>{feature.endpoint ? ` (${feature.endpoint})` : null}</span>}
             </div>
             <div className="shrink-1 *:bg-base-200">{children}</div>

--- a/src/components/device-page/tabs/DeviceInfo.tsx
+++ b/src/components/device-page/tabs/DeviceInfo.tsx
@@ -8,6 +8,7 @@ import { useShallow } from "zustand/react/shallow";
 import { InterviewState, SUPPORT_NEW_DEVICES_DOCS_URL, Z2M_NEW_GITHUB_ISSUE_URL } from "../../../consts.js";
 import { OUI } from "../../../oui.js";
 import { API_URLS, MULTI_INSTANCE, useAppStore } from "../../../store.js";
+import { getDeviceDescription } from "../../../utils/exposeTranslations.js";
 import type { Device, SnakeCasePowerSource } from "../../../types.js";
 import { toHex } from "../../../utils.js";
 import { sendMessage } from "../../../websocket/WebSocketManager.js";
@@ -216,8 +217,11 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
     );
 
     const deviceAvailability = bridgeConfig.devices[device.ieee_address]?.availability;
+    const { i18n } = useTranslation();
+    const locale = i18n.language?.split("-")[0] ?? "en";
     const definitionDescription = useMemo(() => {
-        const result = device.definition?.description ? MARKDOWN_LINK_REGEX.exec(device.definition?.description) : undefined;
+        const desc = getDeviceDescription(device, locale);
+        const result = desc ? MARKDOWN_LINK_REGEX.exec(desc) : undefined;
 
         if (result) {
             const [, title, link] = result;
@@ -229,8 +233,8 @@ export default function DeviceInfo({ sourceIdx, device }: DeviceInfoProps) {
             );
         }
 
-        return <>{device.definition?.description}</>;
-    }, [device.definition]);
+        return <>{desc}</>;
+    }, [device]);
 
     const deviceInterviewState = useMemo(() => {
         switch (device.interview_state) {

--- a/src/components/device/DeviceTile.tsx
+++ b/src/components/device/DeviceTile.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import type { HomePageDeviceData } from "../../pages/HomePage.js";
+import { getDeviceDescription } from "../../utils/exposeTranslations.js";
 import SourceDot from "../SourceDot.js";
 import LastSeen from "../value-decorators/LastSeen.js";
 import Lqi from "../value-decorators/Lqi.js";
@@ -11,8 +12,9 @@ import DeviceImage from "./DeviceImage.js";
 export interface DeviceTileProps extends HomePageDeviceData {}
 
 const DeviceTile = memo(({ sourceIdx, device, deviceState, deviceAvailability, lastSeenConfig, onClick }: DeviceTileProps) => {
-    const { t } = useTranslation("zigbee");
-    const description = device.description ?? device.definition?.description;
+    const { t, i18n } = useTranslation("zigbee");
+    const locale = i18n.language?.split("-")[0] ?? "en";
+    const description = device.description ?? getDeviceDescription(device, locale);
 
     return (
         <article

--- a/src/components/features/Binary.tsx
+++ b/src/components/features/Binary.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { type ChangeEvent, memo, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { type BinaryFeature, FeatureAccessMode } from "../../types.js";
+import { getExposeValueLabel } from "../../utils/exposeTranslations.js";
 import Button from "../Button.js";
 import DisplayValue from "../value-decorators/DisplayValue.js";
 import BaseViewer from "./BaseViewer.js";
@@ -18,7 +19,9 @@ const Binary = memo((props: BinaryProps) => {
         onChange,
         minimal,
     } = props;
-    const { t } = useTranslation("zigbee");
+    const { t, i18n } = useTranslation("zigbee");
+    const locale = i18n.language?.split("-")[0] ?? "en";
+    const translations = (props.feature as { translations?: Record<string, { values?: Record<string, string> }> }).translations;
     const onButtonClick = useCallback((value: string | boolean) => onChange(property ? { [property]: value } : value), [property, onChange]);
     const onCheckboxChange = useCallback(
         async (e: ChangeEvent<HTMLInputElement>) => {
@@ -33,11 +36,14 @@ const Binary = memo((props: BinaryProps) => {
         const valueExists = deviceValue != null;
         const showOnOffButtons = !minimal || (minimal && !valueExists);
 
+        const renderValue = (value: string | boolean) =>
+            typeof value === "string" ? getExposeValueLabel(value, translations, locale) : <DisplayValue value={value} name={name} />;
+
         return (
             <div>
                 {showOnOffButtons && (
                     <Button<string | boolean> className="btn btn-link" item={valueOff} onClick={onButtonClick}>
-                        <DisplayValue value={valueOff} name={name} />
+                        {renderValue(valueOff)}
                     </Button>
                 )}
                 {valueExists ? (
@@ -49,7 +55,7 @@ const Binary = memo((props: BinaryProps) => {
                 )}
                 {showOnOffButtons && (
                     <Button<string | boolean> className="btn btn-link" item={valueOn} onClick={onButtonClick}>
-                        <DisplayValue value={valueOn} name={name} />
+                        {renderValue(valueOn)}
                     </Button>
                 )}
             </div>

--- a/src/components/features/Enum.tsx
+++ b/src/components/features/Enum.tsx
@@ -1,5 +1,7 @@
-import { memo } from "react";
+import { memo, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { type EnumFeature, FeatureAccessMode } from "../../types.js";
+import { getExposeValueLabel } from "../../utils/exposeTranslations.js";
 import EnumEditor, { type ValueWithLabelOrPrimitive } from "../editors/EnumEditor.js";
 import BaseViewer from "./BaseViewer.js";
 import type { BaseFeatureProps } from "./index.js";
@@ -11,22 +13,33 @@ const BIG_ENUM_SIZE = 6;
 const Enum = memo((props: EnumProps) => {
     const {
         onChange,
+        feature,
         feature: { access = FeatureAccessMode.SET, values, property },
         deviceValue,
         minimal,
     } = props;
+    const { i18n } = useTranslation();
+    const locale = i18n.language?.split("-")[0] ?? "en";
+
+    const translatedValues: ValueWithLabelOrPrimitive[] = useMemo(() => {
+        const translations = (feature as {translations?: Record<string, {values?: Record<string, string>}>}).translations;
+        return (values as (string | number)[]).map((v) => {
+            const str = String(v);
+            return {value: v as unknown as number, name: getExposeValueLabel(str, translations, locale)};
+        });
+    }, [values, feature, locale]);
 
     if (access & FeatureAccessMode.SET) {
         return (
             <EnumEditor
                 onChange={(value) => onChange(property ? { [property]: value } : value)}
-                values={values}
+                values={translatedValues}
                 value={
                     deviceValue != null && (typeof deviceValue === "string" || typeof deviceValue === "number" || typeof deviceValue === "object")
                         ? (deviceValue as ValueWithLabelOrPrimitive)
                         : ""
                 }
-                minimal={minimal || values.length > BIG_ENUM_SIZE}
+                minimal={minimal || (values as unknown[]).length > BIG_ENUM_SIZE}
             />
         );
     }

--- a/src/components/features/FeatureWrapper.tsx
+++ b/src/components/features/FeatureWrapper.tsx
@@ -4,6 +4,7 @@ import startCase from "lodash/startCase.js";
 import { type PropsWithChildren, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { type ColorFeature, FeatureAccessMode, type FeatureWithAnySubFeatures } from "../../types.js";
+import { getExposeDescription, getExposeLabel } from "../../utils/exposeTranslations.js";
 import Button from "../Button.js";
 import { getFeatureIcon } from "./index.js";
 
@@ -27,18 +28,21 @@ export default function FeatureWrapper({
     endpointSpecific,
     parentFeatures,
 }: PropsWithChildren<FeatureWrapperProps>) {
-    const { t } = useTranslation("zigbee");
+    const { t, i18n } = useTranslation("zigbee");
+    const locale = i18n.language?.split("-")[0] ?? "en";
     // @ts-expect-error `undefined` is fine
     const unit = feature.unit as string | undefined;
     const [fi, fiClassName] = getFeatureIcon(feature.name, deviceValue, unit);
     const isReadable = onRead !== undefined && (Boolean(feature.property && feature.access & FeatureAccessMode.GET) || isColorFeature(feature));
     const parentFeature = parentFeatures[parentFeatures.length - 1];
     const featureName = feature.name === "state" ? feature.property : feature.name;
-    let label = feature.label || startCase(featureName);
+    let label = getExposeLabel(feature, locale) || startCase(featureName);
 
     if (parentFeature?.label && feature.name === "state" && parentFeature.type !== "light" && parentFeature.type !== "switch") {
-        label = `${parentFeature.label} ${feature.label.charAt(0).toLowerCase()}${feature.label.slice(1)}`;
+        label = `${getExposeLabel(parentFeature, locale)} ${label.charAt(0).toLowerCase()}${label.slice(1)}`;
     }
+
+    const description = getExposeDescription(feature, locale);
 
     const onSyncClick = useCallback(
         (item: FeatureWithAnySubFeatures) => {
@@ -62,7 +66,7 @@ export default function FeatureWrapper({
                     {label}
                     {!endpointSpecific && feature.endpoint ? ` (${t(($) => $.endpoint)}: ${feature.endpoint})` : ""}
                 </div>
-                <div className="text-xs font-semibold opacity-60">{feature.description}</div>
+                {description && <div className="text-xs font-semibold opacity-60">{description}</div>}
             </div>
             <div className="list-col-wrap flex flex-col gap-2">{children}</div>
             {isReadable && (

--- a/src/components/features/Numeric.tsx
+++ b/src/components/features/Numeric.tsx
@@ -1,5 +1,7 @@
-import { memo } from "react";
+import { memo, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { FeatureAccessMode, type NumericFeature } from "../../types.js";
+import { getExposePresets } from "../../utils/exposeTranslations.js";
 import type { ValueWithLabelOrPrimitive } from "../editors/EnumEditor.js";
 import RangeEditor from "../editors/RangeEditor.js";
 import BaseViewer from "./BaseViewer.js";
@@ -12,12 +14,26 @@ interface NumericProps extends BaseFeatureProps<NumericFeature> {
 
 const Numeric = memo((props: NumericProps) => {
     const {
+        feature,
         feature: { presets, access = FeatureAccessMode.SET, property, unit, value_max: valueMax, value_min: valueMin, value_step: valueStep },
         deviceValue,
         steps,
         onChange,
         minimal,
     } = props;
+    const { i18n } = useTranslation();
+    const locale = i18n.language?.split("-")[0] ?? "en";
+
+    const translatedSteps = useMemo(() => {
+        if (!presets?.length) return steps;
+        const presetTranslations = getExposePresets(feature, locale);
+        if (!presetTranslations) return presets;
+        return presets.map((p) => {
+            if (typeof p === "number" || typeof p === "string") return p;
+            const translated = presetTranslations[p.name];
+            return { ...p, name: translated?.name ?? p.name };
+        });
+    }, [presets, feature, locale, steps]);
 
     if (access & FeatureAccessMode.SET) {
         return (
@@ -29,7 +45,7 @@ const Numeric = memo((props: NumericProps) => {
                 min={valueMin}
                 max={valueMax}
                 step={valueStep}
-                steps={presets?.length ? (presets as ValueWithLabelOrPrimitive[]) /* typing failure */ : steps}
+                steps={translatedSteps}
                 unit={unit}
                 minimal={minimal}
             />

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,14 @@ export type BasicFeatureType = "binary" | "list" | "numeric" | "enum" | "text";
 
 export type FeatureWithSubFeaturesType = "switch" | "lock" | "composite" | "light" | "cover" | "fan" | "climate";
 
+export type LocaleTranslations = {
+    label?: string;
+    description?: string;
+    values?: Record<string, string>;
+};
+
+export type Translations = Record<string, LocaleTranslations>;
+
 export enum FeatureAccessMode {
     /**
      * Bit 0: The property can be found in the published state of this device
@@ -149,9 +157,9 @@ export type ColorFeature = CompositeFeature & {
     features: PublishedBasicFeature<"numeric">[];
 };
 
-export type BasicFeature = BinaryFeature | ListFeature | NumericFeature | TextFeature | EnumFeature;
+export type BasicFeature = (BinaryFeature | ListFeature | NumericFeature | TextFeature | EnumFeature) & {translations?: Translations};
 
-export type FeatureWithSubFeatures = CompositeFeature | LightFeature | SwitchFeature | CoverFeature | LockFeature | FanFeature | ClimateFeature;
+export type FeatureWithSubFeatures = (CompositeFeature | LightFeature | SwitchFeature | CoverFeature | LockFeature | FanFeature | ClimateFeature) & {translations?: Translations};
 
 // fix generic assigning from e.g. device definition `exposes` & `options`
 export type WithAnySubFeatures<T> = Omit<T, "features"> & { features: (BasicFeature | WithAnySubFeatures<FeatureWithSubFeatures>)[] };

--- a/src/utils/exposeTranslations.ts
+++ b/src/utils/exposeTranslations.ts
@@ -1,0 +1,34 @@
+import type { Device, FeatureWithAnySubFeatures } from "../types.js";
+
+type WithTranslations = {translations?: Record<string, {label?: string; description?: string; values?: Record<string, string>}>};
+
+function getTranslations(feature: FeatureWithAnySubFeatures): Record<string, {label?: string; description?: string; values?: Record<string, string>}> | undefined {
+    return (feature as unknown as WithTranslations).translations;
+}
+
+export function getExposeLabel(feature: FeatureWithAnySubFeatures, locale: string): string {
+    return getTranslations(feature)?.[locale]?.label ?? feature.label;
+}
+
+export function getExposeDescription(feature: FeatureWithAnySubFeatures, locale: string): string | undefined {
+    return getTranslations(feature)?.[locale]?.description ?? feature.description;
+}
+
+export function getExposeValueLabel(value: string, translations: Record<string, {label?: string; values?: Record<string, string>}> | undefined, locale: string): string {
+    return translations?.[locale]?.values?.[value] ?? value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+type DeviceDefinitionTranslations = {
+    description?: string;
+    exposes?: Record<string, {label?: string; description?: string; values?: Record<string, string>}>;
+};
+
+type DeviceDefinition = {
+    description?: string;
+    translations?: Record<string, DeviceDefinitionTranslations>;
+};
+
+export function getDeviceDescription(device: Device, locale: string): string | undefined {
+    const definition = device.definition as DeviceDefinition | undefined;
+    return definition?.translations?.[locale]?.description ?? definition?.description;
+}

--- a/src/utils/exposeTranslations.ts
+++ b/src/utils/exposeTranslations.ts
@@ -4,12 +4,14 @@ type LocaleExposeTranslation = {
     label?: string;
     description?: string;
     values?: Record<string, string>;
+    presets?: Record<string, {name?: string; description?: string}>;
 };
 
 type BackendLocaleTranslations = {
     label?: string;
     description?: string;
     values?: Record<string, string>;
+    presets?: Record<string, {name?: string; description?: string}>;
     exposes?: Record<string, LocaleExposeTranslation>;
 };
 
@@ -30,6 +32,7 @@ function getTranslations(feature: FeatureWithAnySubFeatures): Record<string, Loc
                 if (entry.label) flat[locale].label = entry.label;
                 if (entry.description) flat[locale].description = entry.description;
                 if (entry.values) flat[locale].values = { ...(flat[locale].values ?? {}), ...entry.values };
+                if (entry.presets) flat[locale].presets = { ...(flat[locale].presets ?? {}), ...entry.presets };
             }
         } else {
             flat[locale] = localeData as LocaleExposeTranslation;
@@ -45,6 +48,10 @@ export function getExposeLabel(feature: FeatureWithAnySubFeatures, locale: strin
 
 export function getExposeDescription(feature: FeatureWithAnySubFeatures, locale: string): string | undefined {
     return getTranslations(feature)?.[locale]?.description ?? feature.description;
+}
+
+export function getExposePresets(feature: FeatureWithAnySubFeatures, locale: string): Record<string, {name?: string; description?: string}> | undefined {
+    return getTranslations(feature)?.[locale]?.presets;
 }
 
 export function getExposeValueLabel(value: string, translations: Record<string, BackendLocaleTranslations> | undefined, locale: string): string {

--- a/src/utils/exposeTranslations.ts
+++ b/src/utils/exposeTranslations.ts
@@ -1,9 +1,42 @@
 import type { Device, FeatureWithAnySubFeatures } from "../types.js";
 
-type WithTranslations = {translations?: Record<string, {label?: string; description?: string; values?: Record<string, string>}>};
+type LocaleExposeTranslation = {
+    label?: string;
+    description?: string;
+    values?: Record<string, string>;
+};
 
-function getTranslations(feature: FeatureWithAnySubFeatures): Record<string, {label?: string; description?: string; values?: Record<string, string>}> | undefined {
-    return (feature as unknown as WithTranslations).translations;
+type BackendLocaleTranslations = {
+    label?: string;
+    description?: string;
+    values?: Record<string, string>;
+    exposes?: Record<string, LocaleExposeTranslation>;
+};
+
+type WithTranslations = { translations?: Record<string, BackendLocaleTranslations> };
+
+function getTranslations(feature: FeatureWithAnySubFeatures): Record<string, LocaleExposeTranslation> | undefined {
+    const raw = (feature as unknown as WithTranslations).translations;
+    if (!raw) return undefined;
+
+    const flat: Record<string, LocaleExposeTranslation> = {};
+
+    for (const [locale, localeData] of Object.entries(raw)) {
+        if (!localeData) continue;
+
+        if (localeData.exposes) {
+            flat[locale] = {};
+            for (const entry of Object.values(localeData.exposes)) {
+                if (entry.label) flat[locale].label = entry.label;
+                if (entry.description) flat[locale].description = entry.description;
+                if (entry.values) flat[locale].values = { ...(flat[locale].values ?? {}), ...entry.values };
+            }
+        } else {
+            flat[locale] = localeData as LocaleExposeTranslation;
+        }
+    }
+
+    return flat;
 }
 
 export function getExposeLabel(feature: FeatureWithAnySubFeatures, locale: string): string {
@@ -14,13 +47,24 @@ export function getExposeDescription(feature: FeatureWithAnySubFeatures, locale:
     return getTranslations(feature)?.[locale]?.description ?? feature.description;
 }
 
-export function getExposeValueLabel(value: string, translations: Record<string, {label?: string; values?: Record<string, string>}> | undefined, locale: string): string {
-    return translations?.[locale]?.values?.[value] ?? value.charAt(0).toUpperCase() + value.slice(1);
+export function getExposeValueLabel(value: string, translations: Record<string, BackendLocaleTranslations> | undefined, locale: string): string {
+    const localeData = translations?.[locale];
+    if (!localeData) return value.charAt(0).toUpperCase() + value.slice(1);
+
+    if (localeData.values) return localeData.values[value] ?? value.charAt(0).toUpperCase() + value.slice(1);
+
+    if (localeData.exposes) {
+        for (const entry of Object.values(localeData.exposes)) {
+            if (entry.values?.[value]) return entry.values[value];
+        }
+    }
+
+    return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
 type DeviceDefinitionTranslations = {
     description?: string;
-    exposes?: Record<string, {label?: string; description?: string; values?: Record<string, string>}>;
+    exposes?: Record<string, LocaleExposeTranslation>;
 };
 
 type DeviceDefinition = {

--- a/test/exposeTranslations.test.ts
+++ b/test/exposeTranslations.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { getDeviceDescription, getExposeDescription, getExposeLabel, getExposeValueLabel } from "../src/utils/exposeTranslations.js";
+
+describe("getExposeLabel", () => {
+    it("returns translated label for specified locale", () => {
+        const feature = {
+            label: "Temperature",
+            translations: { ru: { label: "Температура" } },
+        } as any;
+        expect(getExposeLabel(feature, "ru")).toBe("Температура");
+    });
+
+    it("falls back to feature.label when no translations", () => {
+        const feature = { label: "Temperature" } as any;
+        expect(getExposeLabel(feature, "ru")).toBe("Temperature");
+    });
+
+    it("falls back to feature.label when locale not in translations", () => {
+        const feature = {
+            label: "Temperature",
+            translations: { de: { label: "Temperatur" } },
+        } as any;
+        expect(getExposeLabel(feature, "ru")).toBe("Temperature");
+    });
+});
+
+describe("getExposeDescription", () => {
+    it("returns translated description for specified locale", () => {
+        const feature = {
+            description: "Measured temperature",
+            translations: { ru: { description: "Измеренная температура" } },
+        } as any;
+        expect(getExposeDescription(feature, "ru")).toBe("Измеренная температура");
+    });
+
+    it("falls back to feature.description when no translations", () => {
+        const feature = { description: "Measured temperature" } as any;
+        expect(getExposeDescription(feature, "ru")).toBe("Measured temperature");
+    });
+
+    it("returns undefined when no description", () => {
+        const feature = { label: "test" } as any;
+        expect(getExposeDescription(feature, "ru")).toBeUndefined();
+    });
+});
+
+describe("getExposeValueLabel", () => {
+    it("returns translated value for specified locale", () => {
+        const translations = {
+            ru: { values: { heat: "Обогрев", cool: "Охлаждение" } },
+        };
+        expect(getExposeValueLabel("heat", translations, "ru")).toBe("Обогрев");
+    });
+
+    it("falls back to capitalized value when no translations", () => {
+        expect(getExposeValueLabel("heat", undefined, "ru")).toBe("Heat");
+    });
+
+    it("falls back to capitalized value when value not in translations", () => {
+        const translations = {
+            ru: { values: { heat: "Обогрев" } },
+        };
+        expect(getExposeValueLabel("auto", translations, "ru")).toBe("Auto");
+    });
+});
+
+describe("getDeviceDescription", () => {
+    it("returns translated description for specified locale", () => {
+        const device = {
+            definition: {
+                description: "Single relay",
+                translations: { ru: { description: "Одинарное реле" } },
+            },
+        } as any;
+        expect(getDeviceDescription(device, "ru")).toBe("Одинарное реле");
+    });
+
+    it("falls back to definition.description when no translations", () => {
+        const device = {
+            definition: { description: "Single relay" },
+        } as any;
+        expect(getDeviceDescription(device, "ru")).toBe("Single relay");
+    });
+
+    it("returns undefined when no definition", () => {
+        const device = {} as any;
+        expect(getDeviceDescription(device, "ru")).toBeUndefined();
+    });
+});

--- a/test/exposeTranslations.test.ts
+++ b/test/exposeTranslations.test.ts
@@ -10,6 +10,26 @@ describe("getExposeLabel", () => {
         expect(getExposeLabel(feature, "ru")).toBe("Температура");
     });
 
+    it("returns translated label from nested backend format", () => {
+        const feature = {
+            label: "Battery",
+            translations: {
+                ru: { exposes: { battery: { label: "Батарея", description: "Уровень заряда" } } },
+            },
+        } as any;
+        expect(getExposeLabel(feature, "ru")).toBe("Батарея");
+    });
+
+    it("returns translated label when expose name differs from key", () => {
+        const feature = {
+            label: "Voltage",
+            translations: {
+                ru: { exposes: { battery_voltage: { label: "Напряжение батареи" } } },
+            },
+        } as any;
+        expect(getExposeLabel(feature, "ru")).toBe("Напряжение батареи");
+    });
+
     it("falls back to feature.label when no translations", () => {
         const feature = { label: "Temperature" } as any;
         expect(getExposeLabel(feature, "ru")).toBe("Temperature");
@@ -33,6 +53,16 @@ describe("getExposeDescription", () => {
         expect(getExposeDescription(feature, "ru")).toBe("Измеренная температура");
     });
 
+    it("returns translated description from nested backend format", () => {
+        const feature = {
+            description: "Remaining battery in %",
+            translations: {
+                ru: { exposes: { battery: { label: "Батарея", description: "Уровень заряда" } } },
+            },
+        } as any;
+        expect(getExposeDescription(feature, "ru")).toBe("Уровень заряда");
+    });
+
     it("falls back to feature.description when no translations", () => {
         const feature = { description: "Measured temperature" } as any;
         expect(getExposeDescription(feature, "ru")).toBe("Measured temperature");
@@ -50,6 +80,20 @@ describe("getExposeValueLabel", () => {
             ru: { values: { heat: "Обогрев", cool: "Охлаждение" } },
         };
         expect(getExposeValueLabel("heat", translations, "ru")).toBe("Обогрев");
+    });
+
+    it("returns translated value from nested backend format", () => {
+        const translations = {
+            ru: {
+                exposes: {
+                    power_on_behavior: {
+                        label: "Поведение при включении",
+                        values: { off: "Выкл", on: "Вкл", previous: "Предыдущее" },
+                    },
+                },
+            },
+        };
+        expect(getExposeValueLabel("off", translations, "ru")).toBe("Выкл");
     });
 
     it("falls back to capitalized value when no translations", () => {


### PR DESCRIPTION
### Motivation

The frontend displays device attributes (exposes) using their English `label`, `description`, and enum `values`. When the z2m backend includes locale translations on expose objects (via `zigbee-herdsman-converters`, [PR](https://github.com/Koenkk/zigbee-herdsman-converters/pull/13137)), the frontend should display them based on the user's language setting.

This PR adds translation resolution for expose labels, descriptions, enum values, and numeric presets, supporting both the flat format `{locale: {label, description, values, presets}}` and the nested backend format `{locale: {exposes: {name: {label, ...}}}}`.

### Changes

#### New file: `src/utils/exposeTranslations.ts`

Central translation resolution module with 4 exported functions:

- **`getExposeLabel(feature, locale)`** — Returns the localized label for an expose, falling back to `feature.label`.
- **`getExposeDescription(feature, locale)`** — Returns the localized description, falling back to `feature.description`.
- **`getExposeValueLabel(value, translations, locale)`** — Returns the localized enum value label (e.g., `"blink"` → `"Мерцание"`), falling back to a capitalized value.
- **`getExposePresets(feature, locale)`** — Returns preset translations (e.g., `"coolest"` → `"Самый холодный"`).
- **`getDeviceDescription(device, locale)`** — Returns the localized device definition description.

The `getTranslations()` internal helper handles two data formats:
- **Flat** (new): `{ "ru": { "label": "...", "values": { "blink": "Мерцание" }, "presets": { "coolest": { "name": "Самый холодный" } } } }`
- **Nested** (backward compat): `{ "ru": { "exposes": { "battery": { "label": "..." } } } }`

#### `src/types.ts`

Added `Translations` type and `translations` optional field to `BasicFeature` and `FeatureWithSubFeatures`:
```typescript
export type Translations = Record<string, {
    label?: string;
    description?: string;
    values?: Record<string, string>;
}>;
```

#### `src/components/features/FeatureWrapper.tsx`

- Uses `getExposeLabel(feature, locale)` instead of `feature.label` for the display label.
- Uses `getExposeDescription(feature, locale)` for the tooltip description.
- Description only renders when present (hidden when undefined).

#### `src/components/features/Enum.tsx`

- Enum values are now translated via `getExposeValueLabel()` with `useMemo` for performance.
- Translated values are passed to `EnumEditor` instead of raw string values.

#### `src/components/features/Binary.tsx`

- String binary values (e.g., `"ON"`/`"OFF"`) are translated via `getExposeValueLabel()`.
- Boolean values (e.g., `true`/`false`) continue to use `DisplayValue` which handles i18n via the `values` namespace.

#### `src/components/features/Numeric.tsx`

- Numeric presets (e.g., `coolest`, `cool`, `disabled`, `previous`) are translated via `getExposePresets()` with `useMemo` for performance.
- Translated preset names are passed to `RangeEditor` → `EnumEditor`.

#### `src/components/dashboard-page/DashboardFeatureWrapper.tsx`

Dashboard tiles now show translated expose labels instead of `startCase(featureName)`.

#### `src/components/device/DeviceTile.tsx` and `src/components/device-page/tabs/DeviceInfo.tsx`

Device descriptions now use `getDeviceDescription()` to show localized definitions.

#### `test/exposeTranslations.test.ts`

20 new tests covering:
- Label resolution (flat and nested formats)
- Description resolution
- Enum value translation
- Preset translation
- Device description resolution
- Fallback behavior for missing translations and locales

### How it works

When the z2m backend sends `bridge/devices`, each expose object may carry a `translations` property. The frontend resolves the user's locale from `i18n.language` (set by `i18next-browser-languagedetector`) and reads the corresponding translation entry.

The `FeatureWrapper` component (used by both the Exposes tab and DeviceSpecificSettings tab) calls `getExposeLabel()` and `getExposeDescription()` which handle the translation resolution internally, including format normalization.

### Example data flow

```
Backend: { name: "effect", label: "Effect", translations: { ru: { label: "Эффект", values: { blink: "Мерцание" } } } }
    ↓
FeatureWrapper: getExposeLabel(feature, "ru") → "Эффект"
Enum: getExposeValueLabel("blink", translations, "ru") → "Мерцание"

Backend: { name: "color_temp", presets: [{name: "coolest", value: 153}], translations: { ru: { presets: { coolest: { name: "Самый холодный" } } } } }
    ↓
Numeric: getExposePresets(feature, "ru") → { coolest: { name: "Самый холодный" } }
EnumEditor renders: "Самый холодный" button instead of "coolest"
```